### PR TITLE
Metafields tutorial javascript

### DIFF
--- a/javascript/example-customer-account--metafields--js/.dockerignore
+++ b/javascript/example-customer-account--metafields--js/.dockerignore
@@ -1,0 +1,3 @@
+.cache
+build
+node_modules

--- a/javascript/example-customer-account--metafields--js/.editorconfig
+++ b/javascript/example-customer-account--metafields--js/.editorconfig
@@ -1,0 +1,15 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+# Markdown syntax specifies that trailing whitespaces can be meaningful,
+# so let’s not trim those. e.g. 2 trailing spaces = linebreak (<br />)
+# See https://daringfireball.net/projects/markdown/syntax#p
+[*.md]
+trim_trailing_whitespace = false

--- a/javascript/example-customer-account--metafields--js/.eslintignore
+++ b/javascript/example-customer-account--metafields--js/.eslintignore
@@ -1,0 +1,6 @@
+node_modules
+build
+public/build
+shopify-app-remix
+*/*.yml
+.shopify

--- a/javascript/example-customer-account--metafields--js/.eslintrc.cjs
+++ b/javascript/example-customer-account--metafields--js/.eslintrc.cjs
@@ -1,0 +1,13 @@
+/** @type {import('@types/eslint').Linter.BaseConfig} */
+module.exports = {
+  root: true,
+  extends: [
+    "@remix-run/eslint-config",
+    "@remix-run/eslint-config/node",
+    "@remix-run/eslint-config/jest-testing-library",
+    "prettier",
+  ],
+  globals: {
+    shopify: "readonly"
+  },
+};

--- a/javascript/example-customer-account--metafields--js/.gitignore
+++ b/javascript/example-customer-account--metafields--js/.gitignore
@@ -1,0 +1,13 @@
+node_modules
+
+/.cache
+/build
+/app/build
+/public/build/
+/public/_dev
+/app/public/build
+/prisma/dev.sqlite
+/prisma/dev.sqlite-journal
+database.sqlite
+
+.env

--- a/javascript/example-customer-account--metafields--js/.graphqlrc.ts
+++ b/javascript/example-customer-account--metafields--js/.graphqlrc.ts
@@ -1,0 +1,40 @@
+import fs from "fs";
+import { LATEST_API_VERSION } from "@shopify/shopify-api";
+import { shopifyApiProject, ApiType } from "@shopify/api-codegen-preset";
+import type { IGraphQLConfig } from "graphql-config";
+
+function getConfig() {
+  const config: IGraphQLConfig = {
+    projects: {
+      default: shopifyApiProject({
+        apiType: ApiType.Admin,
+        apiVersion: LATEST_API_VERSION,
+        documents: ["./app/**/*.{js,ts,jsx,tsx}"],
+        outputDir: "./app/types",
+      }),
+    },
+  };
+
+  let extensions: string[] = [];
+  try {
+    extensions = fs.readdirSync("./extensions");
+  } catch {
+    // ignore if no extensions
+  }
+
+  for (const entry of extensions) {
+    const extensionPath = `./extensions/${entry}`;
+    const schema = `${extensionPath}/schema.graphql`;
+    if (!fs.existsSync(schema)) {
+      continue;
+    }
+    config.projects[entry] = {
+      schema,
+      documents: [`${extensionPath}/**/*.graphql`],
+    };
+  }
+
+  return config;
+}
+
+module.exports = getConfig();

--- a/javascript/example-customer-account--metafields--js/.npmrc
+++ b/javascript/example-customer-account--metafields--js/.npmrc
@@ -1,0 +1,5 @@
+engine-strict=true
+auto-install-peers=true
+shamefully-hoist=true
+enable-pre-post-scripts=true
+@shopify:registry=https://registry.npmjs.org

--- a/javascript/example-customer-account--metafields--js/.prettierignore
+++ b/javascript/example-customer-account--metafields--js/.prettierignore
@@ -1,0 +1,7 @@
+package.json
+.shadowenv.d
+.vscode
+node_modules
+prisma
+public
+.shopify

--- a/javascript/example-customer-account--metafields--js/Dockerfile
+++ b/javascript/example-customer-account--metafields--js/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:18-alpine
+
+EXPOSE 3000
+
+WORKDIR /app
+COPY . .
+
+ENV NODE_ENV=production
+
+RUN npm install --omit=dev
+# Remove CLI packages since we don't need them in production by default.
+# Remove this line if you want to run CLI commands in your container.
+RUN npm remove @shopify/app @shopify/cli
+RUN npm run build
+
+# You'll probably want to remove this in production, it's here to make it easier to test things!
+RUN rm -f prisma/dev.sqlite
+
+CMD ["npm", "run", "docker-start"]

--- a/javascript/example-customer-account--metafields--js/README.md
+++ b/javascript/example-customer-account--metafields--js/README.md
@@ -1,0 +1,77 @@
+# Building metafield writes into extensions
+
+This tutorial code introduces a Customer Account UI extension that reads and writes a value from a metafield. The code is based on a template for building a [Shopify app](https://shopify.dev/docs/apps/getting-started) using the [Remix](https://remix.run) framework.
+
+## Your new App and Extension
+
+Some notable files:
+
+- `shopify.app.toml`, the configuration file for your app. This file contains the access scopes that will be required for this example. This file will be automatically updated to include other properties when you run the Shopify CLI preview
+- `shopify.extension.toml`, the configuration file for your extension. This file defines your extension’s name, the target(s), and where the code lives.
+- `app/shopify.server.ts`, contains code that will be triggered upon app installation
+- `src/*.js`, the source code for your extension.
+- `locales/en.default.json` and `locales/fr.json`, which contain translations used to [localized your extension](https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions).
+
+## Quick start
+
+### Prerequisites
+
+Before you begin, you'll need the following:
+
+1. **Node.js**: [Download and install](https://nodejs.org/en/download/) it if you haven't already.
+2. **Shopify Partner Account**: [Create an account](https://partners.shopify.com/signup) if you don't have one.
+3. **Test Store**: Set up a [development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) that's part of the [Checkout and Customer Account Extensibility Dev Preview](https://shopify.dev/docs/api/release-notes/developer-previews#checkout-and-customer-accounts-extensibility-developer-preview) in order to test your app.
+
+### Setup
+
+Using yarn:
+
+```shell
+yarn install
+```
+
+Using npm:
+
+```shell
+npm install
+```
+
+Using pnpm:
+
+```shell
+pnpm install
+```
+
+### Local Development
+
+Using yarn:
+
+```shell
+yarn dev
+```
+
+Using npm:
+
+```shell
+npm run dev
+```
+
+Using pnpm:
+
+```shell
+pnpm run dev
+```
+
+Begin by following the install link to install the app on your development shop.
+
+Press `P` to preview your app.
+
+Local development is powered by [the Shopify CLI](https://shopify.dev/docs/apps/tools/cli). It logs into your partners account, connects to an app, provides environment variables, updates remote config, creates a tunnel and provides commands to generate extensions.
+
+
+## Useful Links
+
+- [Customer account UI extension documentation](https://shopify.dev/docs/api/customer-account-ui-extensions)
+  - [Configuration](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/configuration)
+  - [API Reference](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis)
+  - [UI Components](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/components)

--- a/javascript/example-customer-account--metafields--js/app/db.server.ts
+++ b/javascript/example-customer-account--metafields--js/app/db.server.ts
@@ -1,0 +1,15 @@
+import { PrismaClient } from "@prisma/client";
+
+declare global {
+  var prisma: PrismaClient;
+}
+
+const prisma: PrismaClient = global.prisma || new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") {
+  if (!global.prisma) {
+    global.prisma = new PrismaClient();
+  }
+}
+
+export default prisma;

--- a/javascript/example-customer-account--metafields--js/app/entry.server.tsx
+++ b/javascript/example-customer-account--metafields--js/app/entry.server.tsx
@@ -1,0 +1,58 @@
+import { PassThrough } from "stream";
+import { renderToPipeableStream } from "react-dom/server";
+import { RemixServer } from "@remix-run/react";
+import {
+  createReadableStreamFromReadable,
+  type EntryContext,
+} from "@remix-run/node";
+import { isbot } from "isbot";
+import { addDocumentResponseHeaders } from "./shopify.server";
+
+const ABORT_DELAY = 5000;
+
+export default async function handleRequest(
+  request: Request,
+  responseStatusCode: number,
+  responseHeaders: Headers,
+  remixContext: EntryContext
+) {
+  addDocumentResponseHeaders(request, responseHeaders);
+  const userAgent = request.headers.get("user-agent");
+  const callbackName = isbot(userAgent ?? '')
+    ? "onAllReady"
+    : "onShellReady";
+
+  return new Promise((resolve, reject) => {
+    const { pipe, abort } = renderToPipeableStream(
+      <RemixServer
+        context={remixContext}
+        url={request.url}
+        abortDelay={ABORT_DELAY}
+      />,
+      {
+        [callbackName]: () => {
+          const body = new PassThrough();
+          const stream = createReadableStreamFromReadable(body);
+
+          responseHeaders.set("Content-Type", "text/html");
+          resolve(
+            new Response(stream, {
+              headers: responseHeaders,
+              status: responseStatusCode,
+            })
+          );
+          pipe(body);
+        },
+        onShellError(error) {
+          reject(error);
+        },
+        onError(error) {
+          responseStatusCode = 500;
+          console.error(error);
+        },
+      }
+    );
+
+    setTimeout(abort, ABORT_DELAY);
+  });
+}

--- a/javascript/example-customer-account--metafields--js/app/globals.d.ts
+++ b/javascript/example-customer-account--metafields--js/app/globals.d.ts
@@ -1,0 +1,1 @@
+declare module "*.css";

--- a/javascript/example-customer-account--metafields--js/app/root.tsx
+++ b/javascript/example-customer-account--metafields--js/app/root.tsx
@@ -1,0 +1,30 @@
+import {
+  Links,
+  Meta,
+  Outlet,
+  Scripts,
+  ScrollRestoration,
+} from "@remix-run/react";
+
+export default function App() {
+  return (
+    <html>
+      <head>
+        <meta charSet="utf-8" />
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <link rel="preconnect" href="https://cdn.shopify.com/" />
+        <link
+          rel="stylesheet"
+          href="https://cdn.shopify.com/static/fonts/inter/v4/styles.css"
+        />
+        <Meta />
+        <Links />
+      </head>
+      <body>
+        <Outlet />
+        <ScrollRestoration />
+        <Scripts />
+      </body>
+    </html>
+  );
+}

--- a/javascript/example-customer-account--metafields--js/app/routes/_index/route.tsx
+++ b/javascript/example-customer-account--metafields--js/app/routes/_index/route.tsx
@@ -1,0 +1,58 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { json, redirect } from "@remix-run/node";
+import { Form, useLoaderData } from "@remix-run/react";
+
+import { login } from "../../shopify.server";
+
+import styles from "./styles.module.css";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const url = new URL(request.url);
+
+  if (url.searchParams.get("shop")) {
+    throw redirect(`/app?${url.searchParams.toString()}`);
+  }
+
+  return json({ showForm: Boolean(login) });
+};
+
+export default function App() {
+  const { showForm } = useLoaderData<typeof loader>();
+
+  return (
+    <div className={styles.index}>
+      <div className={styles.content}>
+        <h1 className={styles.heading}>A short heading about [your app]</h1>
+        <p className={styles.text}>
+          A tagline about [your app] that describes your value proposition.
+        </p>
+        {showForm && (
+          <Form className={styles.form} method="post" action="/auth/login">
+            <label className={styles.label}>
+              <span>Shop domain</span>
+              <input className={styles.input} type="text" name="shop" />
+              <span>e.g: my-shop-domain.myshopify.com</span>
+            </label>
+            <button className={styles.button} type="submit">
+              Log in
+            </button>
+          </Form>
+        )}
+        <ul className={styles.list}>
+          <li>
+            <strong>Product feature</strong>. Some detail about your feature and
+            its benefit to your customer.
+          </li>
+          <li>
+            <strong>Product feature</strong>. Some detail about your feature and
+            its benefit to your customer.
+          </li>
+          <li>
+            <strong>Product feature</strong>. Some detail about your feature and
+            its benefit to your customer.
+          </li>
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/javascript/example-customer-account--metafields--js/app/routes/_index/styles.module.css
+++ b/javascript/example-customer-account--metafields--js/app/routes/_index/styles.module.css
@@ -1,0 +1,73 @@
+.index {
+  align-items: center;
+  display: flex;
+  justify-content: center;
+  height: 100%;
+  width: 100%;
+  text-align: center;
+  padding: 1rem;
+}
+
+.heading,
+.text {
+  padding: 0;
+  margin: 0;
+}
+
+.text {
+  font-size: 1.2rem;
+  padding-bottom: 2rem;
+}
+
+.content {
+  display: grid;
+  gap: 2rem;
+}
+
+.form {
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  margin: 0 auto;
+  gap: 1rem;
+}
+
+.label {
+  display: grid;
+  gap: 0.2rem;
+  max-width: 20rem;
+  text-align: left;
+  font-size: 1rem;
+}
+
+.input {
+  padding: 0.4rem;
+}
+
+.button {
+  padding: 0.4rem;
+}
+
+.list {
+  list-style: none;
+  padding: 0;
+  padding-top: 3rem;
+  margin: 0;
+  display: flex;
+  gap: 2rem;
+}
+
+.list > li {
+  max-width: 20rem;
+  text-align: left;
+}
+
+@media only screen and (max-width: 50rem) {
+  .list {
+    display: block;
+  }
+
+  .list > li {
+    padding-bottom: 1rem;
+  }
+}

--- a/javascript/example-customer-account--metafields--js/app/routes/app._index.tsx
+++ b/javascript/example-customer-account--metafields--js/app/routes/app._index.tsx
@@ -1,0 +1,335 @@
+import { useEffect } from "react";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { useActionData, useNavigation, useSubmit } from "@remix-run/react";
+import {
+  Page,
+  Layout,
+  Text,
+  Card,
+  Button,
+  BlockStack,
+  Box,
+  List,
+  Link,
+  InlineStack,
+} from "@shopify/polaris";
+import { TitleBar, useAppBridge } from "@shopify/app-bridge-react";
+import { authenticate } from "../shopify.server";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  await authenticate.admin(request);
+
+  return null;
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { admin } = await authenticate.admin(request);
+  const color = ["Red", "Orange", "Yellow", "Green"][
+    Math.floor(Math.random() * 4)
+  ];
+  const response = await admin.graphql(
+    `#graphql
+      mutation populateProduct($input: ProductInput!) {
+        productCreate(input: $input) {
+          product {
+            id
+            title
+            handle
+            status
+            variants(first: 10) {
+              edges {
+                node {
+                  id
+                  price
+                  barcode
+                  createdAt
+                }
+              }
+            }
+          }
+        }
+      }`,
+    {
+      variables: {
+        input: {
+          title: `${color} Snowboard`,
+        },
+      },
+    },
+  );
+  const responseJson = await response.json();
+
+  const variantId =
+    responseJson.data!.productCreate!.product!.variants.edges[0]!.node!.id!;
+  const variantResponse = await admin.graphql(
+    `#graphql
+      mutation shopifyRemixTemplateUpdateVariant($input: ProductVariantInput!) {
+        productVariantUpdate(input: $input) {
+          productVariant {
+            id
+            price
+            barcode
+            createdAt
+          }
+        }
+      }`,
+    {
+      variables: {
+        input: {
+          id: variantId,
+          price: Math.random() * 100,
+        },
+      },
+    },
+  );
+
+  const variantResponseJson = await variantResponse.json();
+
+  return json({
+    product: responseJson!.data!.productCreate!.product,
+    variant: variantResponseJson!.data!.productVariantUpdate!.productVariant,
+  });
+};
+
+export default function Index() {
+  const nav = useNavigation();
+  const actionData = useActionData<typeof action>();
+  const submit = useSubmit();
+  const shopify = useAppBridge();
+  const isLoading =
+    ["loading", "submitting"].includes(nav.state) && nav.formMethod === "POST";
+  const productId = actionData?.product?.id.replace(
+    "gid://shopify/Product/",
+    "",
+  );
+
+  useEffect(() => {
+    if (productId) {
+      shopify.toast.show("Product created");
+    }
+  }, [productId, shopify]);
+  const generateProduct = () => submit({}, { replace: true, method: "POST" });
+
+  return (
+    <Page>
+      <TitleBar title="Remix app template">
+        <button variant="primary" onClick={generateProduct}>
+          Generate a product
+        </button>
+      </TitleBar>
+      <BlockStack gap="500">
+        <Layout>
+          <Layout.Section>
+            <Card>
+              <BlockStack gap="500">
+                <BlockStack gap="200">
+                  <Text as="h2" variant="headingMd">
+                    Congrats on creating a new Shopify app 🎉
+                  </Text>
+                  <Text variant="bodyMd" as="p">
+                    This embedded app template uses{" "}
+                    <Link
+                      url="https://shopify.dev/docs/apps/tools/app-bridge"
+                      target="_blank"
+                      removeUnderline
+                    >
+                      App Bridge
+                    </Link>{" "}
+                    interface examples like an{" "}
+                    <Link url="/app/additional" removeUnderline>
+                      additional page in the app nav
+                    </Link>
+                    , as well as an{" "}
+                    <Link
+                      url="https://shopify.dev/docs/api/admin-graphql"
+                      target="_blank"
+                      removeUnderline
+                    >
+                      Admin GraphQL
+                    </Link>{" "}
+                    mutation demo, to provide a starting point for app
+                    development.
+                  </Text>
+                </BlockStack>
+                <BlockStack gap="200">
+                  <Text as="h3" variant="headingMd">
+                    Get started with products
+                  </Text>
+                  <Text as="p" variant="bodyMd">
+                    Generate a product with GraphQL and get the JSON output for
+                    that product. Learn more about the{" "}
+                    <Link
+                      url="https://shopify.dev/docs/api/admin-graphql/latest/mutations/productCreate"
+                      target="_blank"
+                      removeUnderline
+                    >
+                      productCreate
+                    </Link>{" "}
+                    mutation in our API references.
+                  </Text>
+                </BlockStack>
+                <InlineStack gap="300">
+                  <Button loading={isLoading} onClick={generateProduct}>
+                    Generate a product
+                  </Button>
+                  {actionData?.product && (
+                    <Button
+                      url={`shopify:admin/products/${productId}`}
+                      target="_blank"
+                      variant="plain"
+                    >
+                      View product
+                    </Button>
+                  )}
+                </InlineStack>
+                {actionData?.product && (
+                  <>
+                    <Text as="h3" variant="headingMd">
+                      {" "}
+                      productCreate mutation
+                    </Text>
+                    <Box
+                      padding="400"
+                      background="bg-surface-active"
+                      borderWidth="025"
+                      borderRadius="200"
+                      borderColor="border"
+                      overflowX="scroll"
+                    >
+                      <pre style={{ margin: 0 }}>
+                        <code>
+                          {JSON.stringify(actionData.product, null, 2)}
+                        </code>
+                      </pre>
+                    </Box>
+                    <Text as="h3" variant="headingMd">
+                      {" "}
+                      productVariantUpdate mutation
+                    </Text>
+                    <Box
+                      padding="400"
+                      background="bg-surface-active"
+                      borderWidth="025"
+                      borderRadius="200"
+                      borderColor="border"
+                      overflowX="scroll"
+                    >
+                      <pre style={{ margin: 0 }}>
+                        <code>
+                          {JSON.stringify(actionData.variant, null, 2)}
+                        </code>
+                      </pre>
+                    </Box>
+                  </>
+                )}
+              </BlockStack>
+            </Card>
+          </Layout.Section>
+          <Layout.Section variant="oneThird">
+            <BlockStack gap="500">
+              <Card>
+                <BlockStack gap="200">
+                  <Text as="h2" variant="headingMd">
+                    App template specs
+                  </Text>
+                  <BlockStack gap="200">
+                    <InlineStack align="space-between">
+                      <Text as="span" variant="bodyMd">
+                        Framework
+                      </Text>
+                      <Link
+                        url="https://remix.run"
+                        target="_blank"
+                        removeUnderline
+                      >
+                        Remix
+                      </Link>
+                    </InlineStack>
+                    <InlineStack align="space-between">
+                      <Text as="span" variant="bodyMd">
+                        Database
+                      </Text>
+                      <Link
+                        url="https://www.prisma.io/"
+                        target="_blank"
+                        removeUnderline
+                      >
+                        Prisma
+                      </Link>
+                    </InlineStack>
+                    <InlineStack align="space-between">
+                      <Text as="span" variant="bodyMd">
+                        Interface
+                      </Text>
+                      <span>
+                        <Link
+                          url="https://polaris.shopify.com"
+                          target="_blank"
+                          removeUnderline
+                        >
+                          Polaris
+                        </Link>
+                        {", "}
+                        <Link
+                          url="https://shopify.dev/docs/apps/tools/app-bridge"
+                          target="_blank"
+                          removeUnderline
+                        >
+                          App Bridge
+                        </Link>
+                      </span>
+                    </InlineStack>
+                    <InlineStack align="space-between">
+                      <Text as="span" variant="bodyMd">
+                        API
+                      </Text>
+                      <Link
+                        url="https://shopify.dev/docs/api/admin-graphql"
+                        target="_blank"
+                        removeUnderline
+                      >
+                        GraphQL API
+                      </Link>
+                    </InlineStack>
+                  </BlockStack>
+                </BlockStack>
+              </Card>
+              <Card>
+                <BlockStack gap="200">
+                  <Text as="h2" variant="headingMd">
+                    Next steps
+                  </Text>
+                  <List>
+                    <List.Item>
+                      Build an{" "}
+                      <Link
+                        url="https://shopify.dev/docs/apps/getting-started/build-app-example"
+                        target="_blank"
+                        removeUnderline
+                      >
+                        {" "}
+                        example app
+                      </Link>{" "}
+                      to get started
+                    </List.Item>
+                    <List.Item>
+                      Explore Shopify’s API with{" "}
+                      <Link
+                        url="https://shopify.dev/docs/apps/tools/graphiql-admin-api"
+                        target="_blank"
+                        removeUnderline
+                      >
+                        GraphiQL
+                      </Link>
+                    </List.Item>
+                  </List>
+                </BlockStack>
+              </Card>
+            </BlockStack>
+          </Layout.Section>
+        </Layout>
+      </BlockStack>
+    </Page>
+  );
+}

--- a/javascript/example-customer-account--metafields--js/app/routes/app.additional.tsx
+++ b/javascript/example-customer-account--metafields--js/app/routes/app.additional.tsx
@@ -1,0 +1,83 @@
+import {
+  Box,
+  Card,
+  Layout,
+  Link,
+  List,
+  Page,
+  Text,
+  BlockStack,
+} from "@shopify/polaris";
+import { TitleBar } from "@shopify/app-bridge-react";
+
+export default function AdditionalPage() {
+  return (
+    <Page>
+      <TitleBar title="Additional page" />
+      <Layout>
+        <Layout.Section>
+          <Card>
+            <BlockStack gap="300">
+              <Text as="p" variant="bodyMd">
+                The app template comes with an additional page which
+                demonstrates how to create multiple pages within app navigation
+                using{" "}
+                <Link
+                  url="https://shopify.dev/docs/apps/tools/app-bridge"
+                  target="_blank"
+                  removeUnderline
+                >
+                  App Bridge
+                </Link>
+                .
+              </Text>
+              <Text as="p" variant="bodyMd">
+                To create your own page and have it show up in the app
+                navigation, add a page inside <Code>app/routes</Code>, and a
+                link to it in the <Code>&lt;NavMenu&gt;</Code> component found
+                in <Code>app/routes/app.jsx</Code>.
+              </Text>
+            </BlockStack>
+          </Card>
+        </Layout.Section>
+        <Layout.Section variant="oneThird">
+          <Card>
+            <BlockStack gap="200">
+              <Text as="h2" variant="headingMd">
+                Resources
+              </Text>
+              <List>
+                <List.Item>
+                  <Link
+                    url="https://shopify.dev/docs/apps/design-guidelines/navigation#app-nav"
+                    target="_blank"
+                    removeUnderline
+                  >
+                    App nav best practices
+                  </Link>
+                </List.Item>
+              </List>
+            </BlockStack>
+          </Card>
+        </Layout.Section>
+      </Layout>
+    </Page>
+  );
+}
+
+function Code({ children }: { children: React.ReactNode }) {
+  return (
+    <Box
+      as="span"
+      padding="025"
+      paddingInlineStart="100"
+      paddingInlineEnd="100"
+      background="bg-surface-active"
+      borderWidth="025"
+      borderColor="border"
+      borderRadius="100"
+    >
+      <code>{children}</code>
+    </Box>
+  );
+}

--- a/javascript/example-customer-account--metafields--js/app/routes/app.tsx
+++ b/javascript/example-customer-account--metafields--js/app/routes/app.tsx
@@ -1,0 +1,42 @@
+import type { HeadersFunction, LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Link, Outlet, useLoaderData, useRouteError } from "@remix-run/react";
+import { boundary } from "@shopify/shopify-app-remix/server";
+import { AppProvider } from "@shopify/shopify-app-remix/react";
+import { NavMenu } from "@shopify/app-bridge-react";
+import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
+
+import { authenticate } from "../shopify.server";
+
+export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  await authenticate.admin(request);
+
+  return json({ apiKey: process.env.SHOPIFY_API_KEY || "" });
+};
+
+export default function App() {
+  const { apiKey } = useLoaderData<typeof loader>();
+
+  return (
+    <AppProvider isEmbeddedApp apiKey={apiKey}>
+      <NavMenu>
+        <Link to="/app" rel="home">
+          Home
+        </Link>
+        <Link to="/app/additional">Additional page</Link>
+      </NavMenu>
+      <Outlet />
+    </AppProvider>
+  );
+}
+
+// Shopify needs Remix to catch some thrown responses, so that their headers are included in the response.
+export function ErrorBoundary() {
+  return boundary.error(useRouteError());
+}
+
+export const headers: HeadersFunction = (headersArgs) => {
+  return boundary.headers(headersArgs);
+};

--- a/javascript/example-customer-account--metafields--js/app/routes/auth.$.tsx
+++ b/javascript/example-customer-account--metafields--js/app/routes/auth.$.tsx
@@ -1,0 +1,8 @@
+import type { LoaderFunctionArgs } from "@remix-run/node";
+import { authenticate } from "../shopify.server";
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  await authenticate.admin(request);
+
+  return null;
+};

--- a/javascript/example-customer-account--metafields--js/app/routes/auth.login/error.server.tsx
+++ b/javascript/example-customer-account--metafields--js/app/routes/auth.login/error.server.tsx
@@ -1,0 +1,16 @@
+import type { LoginError } from "@shopify/shopify-app-remix/server";
+import { LoginErrorType } from "@shopify/shopify-app-remix/server";
+
+interface LoginErrorMessage {
+  shop?: string;
+}
+
+export function loginErrorMessage(loginErrors: LoginError): LoginErrorMessage {
+  if (loginErrors?.shop === LoginErrorType.MissingShop) {
+    return { shop: "Please enter your shop domain to log in" };
+  } else if (loginErrors?.shop === LoginErrorType.InvalidShop) {
+    return { shop: "Please enter a valid shop domain to log in" };
+  }
+
+  return {};
+}

--- a/javascript/example-customer-account--metafields--js/app/routes/auth.login/route.tsx
+++ b/javascript/example-customer-account--metafields--js/app/routes/auth.login/route.tsx
@@ -1,0 +1,69 @@
+import { useState } from "react";
+import type { ActionFunctionArgs, LoaderFunctionArgs } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { Form, useActionData, useLoaderData } from "@remix-run/react";
+import {
+  AppProvider as PolarisAppProvider,
+  Button,
+  Card,
+  FormLayout,
+  Page,
+  Text,
+  TextField,
+} from "@shopify/polaris";
+import polarisTranslations from "@shopify/polaris/locales/en.json";
+import polarisStyles from "@shopify/polaris/build/esm/styles.css?url";
+
+import { login } from "../../shopify.server";
+
+import { loginErrorMessage } from "./error.server";
+
+export const links = () => [{ rel: "stylesheet", href: polarisStyles }];
+
+export const loader = async ({ request }: LoaderFunctionArgs) => {
+  const errors = loginErrorMessage(await login(request));
+
+  return json({ errors, polarisTranslations });
+};
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const errors = loginErrorMessage(await login(request));
+
+  return json({
+    errors,
+  });
+};
+
+export default function Auth() {
+  const loaderData = useLoaderData<typeof loader>();
+  const actionData = useActionData<typeof action>();
+  const [shop, setShop] = useState("");
+  const { errors } = actionData || loaderData;
+
+  return (
+    <PolarisAppProvider i18n={loaderData.polarisTranslations}>
+      <Page>
+        <Card>
+          <Form method="post">
+            <FormLayout>
+              <Text variant="headingMd" as="h2">
+                Log in
+              </Text>
+              <TextField
+                type="text"
+                name="shop"
+                label="Shop domain"
+                helpText="example.myshopify.com"
+                value={shop}
+                onChange={setShop}
+                autoComplete="on"
+                error={errors.shop}
+              />
+              <Button submit>Log in</Button>
+            </FormLayout>
+          </Form>
+        </Card>
+      </Page>
+    </PolarisAppProvider>
+  );
+}

--- a/javascript/example-customer-account--metafields--js/app/routes/webhooks.tsx
+++ b/javascript/example-customer-account--metafields--js/app/routes/webhooks.tsx
@@ -1,0 +1,28 @@
+import type { ActionFunctionArgs } from "@remix-run/node";
+import { authenticate } from "../shopify.server";
+import db from "../db.server";
+
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const { topic, shop, session, admin } = await authenticate.webhook(request);
+
+  if (!admin) {
+    // The admin context isn't returned if the webhook fired after a shop was uninstalled.
+    throw new Response();
+  }
+
+  switch (topic) {
+    case "APP_UNINSTALLED":
+      if (session) {
+        await db.session.deleteMany({ where: { shop } });
+      }
+
+      break;
+    case "CUSTOMERS_DATA_REQUEST":
+    case "CUSTOMERS_REDACT":
+    case "SHOP_REDACT":
+    default:
+      throw new Response("Unhandled webhook topic", { status: 404 });
+  }
+
+  throw new Response();
+};

--- a/javascript/example-customer-account--metafields--js/app/shopify.server.ts
+++ b/javascript/example-customer-account--metafields--js/app/shopify.server.ts
@@ -1,0 +1,131 @@
+import "@shopify/shopify-app-remix/adapters/node";
+import {
+  ApiVersion,
+  AppDistribution,
+  DeliveryMethod,
+  shopifyApp,
+} from "@shopify/shopify-app-remix/server";
+import { PrismaSessionStorage } from "@shopify/shopify-app-session-storage-prisma";
+import { restResources } from "@shopify/shopify-api/rest/admin/2024-04";
+import prisma from "./db.server";
+import type { AdminApiContext } from "node_modules/@shopify/shopify-app-remix/dist/ts/server/clients";
+import type { ShopifyRestResources } from "@shopify/shopify-api";
+
+const shopify = shopifyApp({
+  apiKey: process.env.SHOPIFY_API_KEY,
+  apiSecretKey: process.env.SHOPIFY_API_SECRET || "",
+  apiVersion: ApiVersion.Unstable,
+  scopes: process.env.SCOPES?.split(","),
+  appUrl: process.env.SHOPIFY_APP_URL || "",
+  authPathPrefix: "/auth",
+  sessionStorage: new PrismaSessionStorage(prisma),
+  distribution: AppDistribution.AppStore,
+  restResources,
+  webhooks: {
+    APP_UNINSTALLED: {
+      deliveryMethod: DeliveryMethod.Http,
+      callbackUrl: "/webhooks",
+    },
+  },
+  hooks: {
+    // [START create-metafield-definition.after-auth]
+    afterAuth: async ({ admin, session }) => {
+      await shopify.registerWebhooks({ session });
+
+      try {
+        const metafield = await getMetafield(admin);
+
+        if (metafield == null) {
+          await createMetafield(admin);
+        }
+      } catch (error: any) {
+        if ("graphQLErrors" in error) {
+          console.error(error.graphQLErrors);
+        } else {
+          console.error(error);
+        }
+
+        throw error;
+      }
+    },
+    // [END create-metafield-definition.after-auth]
+  },
+  future: {
+    unstable_newEmbeddedAuthStrategy: true,
+  },
+  ...(process.env.SHOP_CUSTOM_DOMAIN
+    ? { customShopDomains: [process.env.SHOP_CUSTOM_DOMAIN] }
+    : {}),
+});
+
+export default shopify;
+export const apiVersion = ApiVersion.Unstable;
+export const addDocumentResponseHeaders = shopify.addDocumentResponseHeaders;
+export const authenticate = shopify.authenticate;
+export const unauthenticated = shopify.unauthenticated;
+export const login = shopify.login;
+export const registerWebhooks = shopify.registerWebhooks;
+export const sessionStorage = shopify.sessionStorage;
+
+// [START create-metafield-definition.get-metafield]
+async function getMetafield(admin: AdminApiContext<ShopifyRestResources>) {
+  const response = await admin.graphql(getMetafieldQuery, {
+    variables: {
+      key: "nickname",
+      namespace: "$app:preferences",
+      ownerType: "CUSTOMER",
+    },
+  });
+
+  const json = await response.json();
+  return json.data?.metafieldDefinitions.nodes[0];
+}
+
+const getMetafieldQuery = `#graphql
+query getMetafieldDefinition($key: String!, $namespace: String!, $ownerType: MetafieldOwnerType!) {
+  metafieldDefinitions(first: 1, key: $key, namespace: $namespace, ownerType: $ownerType) {
+    nodes {
+      id
+    }
+  }
+}
+`;
+// [END create-metafield-definition.get-metafield]
+
+// [START create-metafield-definition.create-metafield]
+async function createMetafield(admin: AdminApiContext<ShopifyRestResources>) {
+  const response = await admin.graphql(createMetafieldMutation, {
+    variables: {
+      definition: {
+        access: {
+          customerAccount: "READ_WRITE",
+          admin: "PRIVATE"
+        },
+        key: "nickname",
+        name: "The customer's preferred name",
+        namespace: "$app:preferences",
+        ownerType: "CUSTOMER",
+        type: "single_line_text_field",
+      },
+    },
+  });
+
+  const json = await response.json();
+  console.log(JSON.stringify(json, null, 2));
+}
+
+const createMetafieldMutation = `#graphql
+mutation metafieldDefinitionCreate($definition: MetafieldDefinitionInput!) {
+  metafieldDefinitionCreate(definition: $definition) {
+    createdDefinition {
+      key
+      namespace
+    }
+    userErrors {
+      field
+      message
+    }
+  }
+}
+`;
+// [END create-metafield-definition.create-metafield]

--- a/javascript/example-customer-account--metafields--js/env.d.ts
+++ b/javascript/example-customer-account--metafields--js/env.d.ts
@@ -1,0 +1,2 @@
+/// <reference types="vite/client" />
+/// <reference types="@remix-run/node" />

--- a/javascript/example-customer-account--metafields--js/extensions/customer-preferences/locales/en.default.json
+++ b/javascript/example-customer-account--metafields--js/extensions/customer-preferences/locales/en.default.json
@@ -1,0 +1,12 @@
+{
+  "preferenceCard": {
+    "heading": "Preferences",
+    "nickName": {
+      "label": "Nickname"
+    },
+    "edit": "Edit",
+    "modalHeading": "Edit preferences",
+    "save": "Save",
+    "cancel": "Cancel"
+  }
+}

--- a/javascript/example-customer-account--metafields--js/extensions/customer-preferences/locales/fr.json
+++ b/javascript/example-customer-account--metafields--js/extensions/customer-preferences/locales/fr.json
@@ -1,0 +1,12 @@
+{
+  "preferenceCard": {
+    "heading": "Préférences",
+    "nickName": {
+      "label": "Surnom"
+    },
+    "edit": "Modifier",
+    "modalHeading": "Modifier les préférences",
+    "save": "Sauvegarder",
+    "cancel": "Annuler"
+  }
+}

--- a/javascript/example-customer-account--metafields--js/extensions/customer-preferences/package.json
+++ b/javascript/example-customer-account--metafields--js/extensions/customer-preferences/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "customer-preferences-js",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "@shopify/ui-extensions": "unstable",
+    "@shopify/ui-extensions-react": "unstable"
+  }
+}

--- a/javascript/example-customer-account--metafields--js/extensions/customer-preferences/shopify.extension.toml
+++ b/javascript/example-customer-account--metafields--js/extensions/customer-preferences/shopify.extension.toml
@@ -1,0 +1,17 @@
+# Learn more about configuring your Customer account UI extension:
+# https://shopify.dev/api/customer-account-ui-extensions/unstable/configuration
+
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "unstable"
+
+[[extensions]]
+name = "customer-preferences-js"
+handle = "customer-preferences-js"
+type = "ui_extension"
+
+# [START setup-targets.config]
+[[extensions.targeting]]
+module = "./src/ProfilePreferenceExtension.js"
+target = "customer-account.profile.block.render"
+# [END setup-targets.config]

--- a/javascript/example-customer-account--metafields--js/extensions/customer-preferences/src/ProfilePreferenceExtension.js
+++ b/javascript/example-customer-account--metafields--js/extensions/customer-preferences/src/ProfilePreferenceExtension.js
@@ -1,0 +1,173 @@
+import {
+  BlockStack,
+  Button,
+  Card,
+  Form,
+  TextField,
+  Heading,
+  Icon,
+  InlineStack,
+  Modal,
+  extension,
+  Text,
+} from "@shopify/ui-extensions/customer-account";
+
+// [START setup-targets.extension]
+export default extension(
+  "customer-account.profile.block.render",
+  async (root, api) => {
+    const { customerId, nickName } = await getCustomerPreferences();
+
+    renderProfilePreferenceExtension(root, api, customerId, nickName);
+  },
+);
+// [END setup-targets.extension]
+
+// [START build-extension.ui]
+function renderProfilePreferenceExtension(root, api, customerId, nickName) {
+  const { i18n, ui } = api;
+
+  const setNickName = (value) => {
+    nickName = value;
+  };
+
+  const handleSubmit = async () => {
+
+    if (!nickName) {
+      return;
+    }
+
+    await setCustomerPreferences(customerId, nickName);
+
+    nickNameText.update(nickName);
+    nickNameTextField.updateProps({ value: nickName });
+
+    ui.overlay.close("edit-preferences-modal");
+  };
+
+  const handleCancel = () => {
+    ui.overlay.close("edit-preferences-modal");
+  };
+
+  const nickNameTextField = root.createComponent(TextField, {
+    label: i18n.translate("preferenceCard.nickName.label"),
+    value: nickName,
+    onChange: setNickName,
+  });
+  const modal = root.createComponent(Modal, {
+    id: "edit-preferences-modal",
+    padding: true,
+    title: i18n.translate("preferenceCard.modalHeading"),
+  }, [
+    root.createComponent(Form, { onSubmit: handleSubmit }, [
+      root.createComponent(BlockStack, undefined, [
+        nickNameTextField,
+        root.createComponent(InlineStack, { blockAlignment: "center", inlineAlignment: "end" }, [
+          root.createComponent(Button, { kind: "plain", onPress: handleCancel }, i18n.translate("preferenceCard.cancel")),
+          root.createComponent(Button, { accessibilityRole: "submit" }, i18n.translate("preferenceCard.save")),
+        ])
+      ]),
+    ]),
+  ]);
+
+  const modalFragment = root.createFragment();
+  modalFragment.appendChild(modal);
+
+  const nickNameText = root.createText(nickName);
+  const preferenceCard = root.createComponent(
+    Card,
+    { padding: true },
+    [
+      root.createComponent(BlockStack, { spacing: "loose" }, [
+        root.createComponent(Heading, { level: 3 }, [
+          root.createComponent(InlineStack, undefined, [
+            root.createComponent(Text, undefined, i18n.translate("preferenceCard.heading")),
+            root.createComponent(Button, {
+              kind: "plain",
+              accessibilityLabel: i18n.translate("preferenceCard.edit"),
+              overlay: modalFragment,
+            }, [
+              root.createComponent(Icon, { source: "pen", size: "small", appearance: "monochrome"}),
+            ]),
+          ]),
+        ]),
+        root.createComponent(BlockStack, { spacing: "loose" }, [
+          root.createComponent(Text, { appearance: "subdued" }, i18n.translate("preferenceCard.nickName.label")),
+          nickNameText,
+        ]),
+      ]),
+    ]
+  );
+
+  root.append(preferenceCard);
+}
+// [END build-extension.ui]
+
+// [START build-extension.get-value]
+async function getCustomerPreferences() {
+  const response = await fetch(
+    "shopify:customer-account/api/2024-07/graphql.json",
+    {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        query: `query preferences($key: String!, $namespace: String!) {
+          customer {
+          id
+            metafield(namespace: $namespace, key: $key) {
+              value
+            }
+          }
+        }`,
+        variables: {
+          key: "nickname",
+          namespace: "$app:preferences",
+        },
+      }),
+    },
+  );
+
+  const { data } = await response.json();
+
+  return {
+    customerId: data.customer.id,
+    nickName: data.customer.metafield?.value,
+  };
+}
+// [END build-extension.get-value]
+
+// [START write-metafield.mutation]
+async function setCustomerPreferences(customerId, newNickName) {
+  await fetch("shopify:customer-account/api/2024-07/graphql.json", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      query: `mutation setPreferences($metafields: [MetafieldsSetInput!]!) {
+          metafieldsSet(metafields: $metafields) {
+            metafields {
+              value
+            }
+            userErrors {
+              field
+              message
+            }
+          }
+        }`,
+      variables: {
+        metafields: [
+          {
+            key: "nickname",
+            namespace: "$app:preferences",
+            ownerId: customerId,
+            value: newNickName ?? "",
+          },
+        ],
+      },
+    }),
+  });
+}
+// [END write-metafield.mutation]

--- a/javascript/example-customer-account--metafields--js/package.json
+++ b/javascript/example-customer-account--metafields--js/package.json
@@ -1,0 +1,71 @@
+{
+  "name": "metafields-tutorial",
+  "private": true,
+  "scripts": {
+    "build": "remix vite:build",
+    "dev": "shopify app dev",
+    "config:link": "shopify app config link",
+    "generate": "shopify app generate",
+    "deploy": "shopify app deploy",
+    "config:use": "shopify app config use",
+    "env": "shopify app env",
+    "start": "remix-serve ./build/server/index.js",
+    "docker-start": "npm run setup && npm run start",
+    "setup": "prisma generate && prisma migrate deploy",
+    "lint": "eslint --cache --cache-location ./node_modules/.cache/eslint .",
+    "shopify": "shopify",
+    "prisma": "prisma",
+    "graphql-codegen": "graphql-codegen",
+    "vite": "vite"
+  },
+  "type": "module",
+  "engines": {
+    "node": ">=18.20.0"
+  },
+  "dependencies": {
+    "@prisma/client": "^5.11.0",
+    "@remix-run/dev": "^2.7.1",
+    "@remix-run/node": "^2.7.1",
+    "@remix-run/react": "^2.7.1",
+    "@remix-run/serve": "^2.7.1",
+    "@shopify/app-bridge-react": "^4.1.2",
+    "@shopify/polaris": "^12.0.0",
+    "@shopify/shopify-api": "^11.0.0",
+    "@shopify/shopify-app-remix": "^3.0.0",
+    "@shopify/shopify-app-session-storage-prisma": "^5.0.0",
+    "@shopify/app": "nightly",
+    "@shopify/cli": "nightly",
+    "@shopify/ui-extensions": "unstable",
+    "@shopify/ui-extensions-react": "unstable",
+    "isbot": "^5.1.0",
+    "prisma": "^5.11.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "vite-tsconfig-paths": "^4.3.1"
+  },
+  "devDependencies": {
+    "@remix-run/eslint-config": "^2.7.1",
+    "@shopify/api-codegen-preset": "^1.0.0",
+    "@types/eslint": "^8.40.0",
+    "@types/node": "^20.6.3",
+    "@types/react": "^18.2.31",
+    "@types/react-dom": "^18.2.14",
+    "eslint": "^8.42.0",
+    "eslint-config-prettier": "^9.1.0",
+    "prettier": "^3.2.4",
+    "typescript": "^5.2.2",
+    "vite": "^5.1.3"
+  },
+  "workspaces": [
+    "extensions/*"
+  ],
+  "trustedDependencies": [
+    "@shopify/plugin-cloudflare"
+  ],
+  "resolutions": {
+    "undici": "6.13.0"
+  },
+  "overrides": {
+    "undici": "6.13.0"
+  }
+}

--- a/javascript/example-customer-account--metafields--js/shopify.app.toml
+++ b/javascript/example-customer-account--metafields--js/shopify.app.toml
@@ -1,0 +1,3 @@
+# [START config.setup-scopes]
+scopes = "customer_read_customers,customer_write_customers,write_customers"
+# [END config.setup-scopes]

--- a/javascript/example-customer-account--metafields--js/shopify.web.toml
+++ b/javascript/example-customer-account--metafields--js/shopify.web.toml
@@ -1,0 +1,6 @@
+name = "remix"
+roles = ["frontend", "backend"]
+webhooks_path = "/webhooks"
+
+[commands]
+dev = "npx prisma generate && npx prisma migrate deploy && npm exec remix vite:dev"

--- a/javascript/example-customer-account--metafields--js/tsconfig.json
+++ b/javascript/example-customer-account--metafields--js/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "include": ["env.d.ts", "**/*.ts", "**/*.tsx"],
+  "compilerOptions": {
+    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "strict": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "allowSyntheticDefaultImports": true,
+    "removeComments": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "jsx": "react-jsx",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "baseUrl": ".",
+    "paths": {
+      "~/*": ["./app/*"]
+    },
+    "types": ["node"]
+  }
+}

--- a/javascript/example-customer-account--metafields--js/vite.config.ts
+++ b/javascript/example-customer-account--metafields--js/vite.config.ts
@@ -1,0 +1,55 @@
+import { vitePlugin as remix } from "@remix-run/dev";
+import { defineConfig, type UserConfig } from "vite";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+// Related: https://github.com/remix-run/remix/issues/2835#issuecomment-1144102176
+// Replace the HOST env var with SHOPIFY_APP_URL so that it doesn't break the remix server. The CLI will eventually
+// stop passing in HOST, so we can remove this workaround after the next major release.
+if (
+  process.env.HOST &&
+  (!process.env.SHOPIFY_APP_URL ||
+    process.env.SHOPIFY_APP_URL === process.env.HOST)
+) {
+  process.env.SHOPIFY_APP_URL = process.env.HOST;
+  delete process.env.HOST;
+}
+
+const host = new URL(process.env.SHOPIFY_APP_URL || "http://localhost")
+  .hostname;
+
+let hmrConfig;
+if (host === "localhost") {
+  hmrConfig = {
+    protocol: "ws",
+    host: "localhost",
+    port: 64999,
+    clientPort: 64999,
+  };
+} else {
+  hmrConfig = {
+    protocol: "wss",
+    host: host,
+    port: parseInt(process.env.FRONTEND_PORT!) || 8002,
+    clientPort: 443,
+  };
+}
+
+export default defineConfig({
+  server: {
+    port: Number(process.env.PORT || 3000),
+    hmr: hmrConfig,
+    fs: {
+      // See https://vitejs.dev/config/server-options.html#server-fs-allow for more information
+      allow: ["app", "node_modules"],
+    },
+  },
+  plugins: [
+    remix({
+      ignoredRouteFiles: ["**/.*"],
+    }),
+    tsconfigPaths(),
+  ],
+  build: {
+    assetsInlineLimit: 0,
+  },
+}) satisfies UserConfig;


### PR DESCRIPTION
A JS version of the customer account extension and writing to metafields tutorial. 

This is a copy of the [React version of the tutorial code](https://github.com/Shopify/customer-account-tutorials/tree/main/react/example-customer-account--metafields--react), but with updates to:
* [shopify.extension.toml](https://github.com/Shopify/customer-account-tutorials/compare/metafields-tutorial-js?expand=1#diff-7773119742b4669e65a424da421d03f684428a780a4c23d25d0d51a4fcd45598)
* [ProfilePreferenceExtension.js](https://github.com/Shopify/customer-account-tutorials/compare/metafields-tutorial-js?expand=1#diff-8aa44f9b4bb419ea56e1b06130f66ca6a6ac0670444cefc0baebbb72c1ce55a3)

The Remix part of the tutorial remains in React & TS, but the extension itself is now Vanilla JS.

Contact me for testing steps.