### PR TITLE
Update tag locations in Metafields Tutorial

### DIFF
--- a/javascript/example-customer-account--metafields--js/app/shopify.server.ts
+++ b/javascript/example-customer-account--metafields--js/app/shopify.server.ts
@@ -27,8 +27,8 @@ const shopify = shopifyApp({
       callbackUrl: "/webhooks",
     },
   },
+  // [START create-metafield-definition.after-auth]
   hooks: {
-    // [START create-metafield-definition.after-auth]
     afterAuth: async ({ admin, session }) => {
       await shopify.registerWebhooks({ session });
 
@@ -48,8 +48,8 @@ const shopify = shopifyApp({
         throw error;
       }
     },
-    // [END create-metafield-definition.after-auth]
   },
+  // [END create-metafield-definition.after-auth]
   future: {
     unstable_newEmbeddedAuthStrategy: true,
   },

--- a/react/example-customer-account--metafields--react/app/shopify.server.ts
+++ b/react/example-customer-account--metafields--react/app/shopify.server.ts
@@ -27,8 +27,8 @@ const shopify = shopifyApp({
       callbackUrl: "/webhooks",
     },
   },
+  // [START create-metafield-definition.after-auth]
   hooks: {
-    // [START create-metafield-definition.after-auth]
     afterAuth: async ({ admin, session }) => {
       await shopify.registerWebhooks({ session });
 
@@ -48,8 +48,8 @@ const shopify = shopifyApp({
         throw error;
       }
     },
-    // [END create-metafield-definition.after-auth]
   },
+  // [END create-metafield-definition.after-auth]
   future: {
     unstable_newEmbeddedAuthStrategy: true,
   },


### PR DESCRIPTION
The Shopify Remix app template was changed [here](https://github.com/Shopify/shopify-app-template-remix/commit/5288147b0d811bfc79717cd9c0cb39a4ce615a41) to remove imperative webhooks. (e.g. the `hooks` property in `shopify.server.ts`)

We're updating the tags in this tutorial to reflect that the whole `hooks` hash needs to be copied.