### PR TITLE
fix wrong customer api version in code tutorial

### DIFF
--- a/react/example-customer-account--order-action-menu--react/extensions/action-menu-extension-react/src/MenuActionExtension.tsx
+++ b/react/example-customer-account--order-action-menu--react/extensions/action-menu-extension-react/src/MenuActionExtension.tsx
@@ -24,7 +24,7 @@ export default reactExtension(
         }`,
       };
       const result = await fetch(
-        "shopify://customer-account/api/latest/graphql.json",
+        "shopify://customer-account/api/unstable/graphql.json",
         {
           method: "POST",
           headers: {


### PR DESCRIPTION
Part of this ticket https://github.com/Shopify/shopify-dev/issues/47577 .

Mainly since @jrrafols  brought versioned customer api support in this PR https://github.com/Shopify/customer-account-web/pull/4931, we only support valid versions here https://shopify.dev/docs/api/customer/. `latest` is not a valid version. 