### PR TITLE
Migrate order status fulfillment extension to preact

### DIFF
--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/README.md
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/README.md
@@ -1,0 +1,21 @@
+# Customer account UI Extension
+
+## Prerequisites
+
+Before you start building your extension, make sure that you've created a [development store](https://shopify.dev/docs/apps/tools/development-stores) with the [Checkout and Customer Accounts Extensibility](https://shopify.dev/docs/api/release-notes/developer-previews#previewing-new-features).
+
+## Your new Extension
+
+Your new extension contains the following files:
+
+- `README.md`, the file you are reading right now.
+- `shopify.extension.toml`, the configuration file for your extension. This file defines your extension's name.
+- `src/*.jsx`, the source code for your extension.
+- `locales/en.default.json` and `locales/fr.json`, which contain translations used to [localized your extension](https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions).
+
+## Useful Links
+
+- [Customer account UI extension documentation](https://shopify.dev/docs/api/customer-account-ui-extensions)
+  - [Configuration](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/configuration)
+  - [API Reference](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis)
+  - [UI Components](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/components)

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/package.json
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ca-loyalty-order-status-fulfillment",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/shopify.d.ts
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/shopify.d.ts
@@ -1,0 +1,7 @@
+import '@shopify/ui-extensions';
+
+//@ts-ignore
+declare module './src/FulfillmentDelivery.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.order-status.fulfillment-details.render-after').Api;
+  const globalThis: { shopify: typeof shopify };
+}

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/shopify.extension.toml
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/shopify.extension.toml
@@ -1,0 +1,14 @@
+api_version = "2025-10"
+
+[[extensions]]
+uid = "9a9cc029-b449-d82d-d072-f613da8fa52aa33c4be4"
+type = "ui_extension"
+name = "ca-loyalty-order-status-fulfillment"
+handle = "ca-loyalty-order-status-fulfillment"
+
+[[extensions.targeting]]
+module = "./src/FulfillmentDelivery.jsx"
+target = "customer-account.order-status.fulfillment-details.render-after"
+
+[extensions.capabilities]
+api_access = true

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/src/FulfillmentDelivery.jsx
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/src/FulfillmentDelivery.jsx
@@ -1,0 +1,20 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<CustomerFulfillmentDetailsDelivery />, document.body);
+};
+
+// [START order-status-static.build-ui]
+function CustomerFulfillmentDetailsDelivery() {
+  return (
+    <s-stack direction="block" gap="base">
+      <s-divider />
+      <s-text>Tell us how we did for a chance to win 1000 points</s-text>
+      <s-stack direction="block" max-inline-size="150">
+        <s-link>Write a review</s-link>
+      </s-stack>
+    </s-stack>
+  );
+}
+// [END order-status-static.build-ui]

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/tsconfig.json
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
Part of https://github.com/shop/issues-checkout/issues/7751

Migrate the order status fulfillment extension example to preact.

Here is the extension rendering in customer accounts: 

<img width="880" height="449" alt="Screenshot 2025-09-09 at 1 11 18 PM" src="https://github.com/user-attachments/assets/0a854db6-f3c1-4438-96ef-0ed641743d25" />