### PR TITLE
Migrate loyalty app profile block extension to preact

### DIFF
--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/README.md
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/README.md
@@ -1,0 +1,21 @@
+# Customer account UI Extension
+
+## Prerequisites
+
+Before you start building your extension, make sure that you’ve created a [development store](https://shopify.dev/docs/apps/tools/development-stores) with the [Checkout and Customer Accounts Extensibility](https://shopify.dev/docs/api/release-notes/developer-previews#previewing-new-features).
+
+## Your new Extension
+
+Your new extension contains the following files:
+
+- `README.md`, the file you are reading right now.
+- `shopify.extension.toml`, the configuration file for your extension. This file defines your extension’s name.
+- `src/*.jsx`, the source code for your extension.
+- `locales/en.default.json` and `locales/fr.json`, which contain translations used to [localized your extension](https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions).
+
+## Useful Links
+
+- [Customer account UI extension documentation](https://shopify.dev/docs/api/customer-account-ui-extensions)
+  - [Configuration](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/configuration)
+  - [API Reference](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis)
+  - [UI Components](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/components)

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/package.json
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "ca-loyalty-profile",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/shopify.d.ts
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/shopify.d.ts
@@ -1,0 +1,7 @@
+import '@shopify/ui-extensions';
+
+//@ts-ignore
+declare module './src/ProfileBlockExtension.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.profile.block.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/shopify.extension.toml
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/shopify.extension.toml
@@ -1,0 +1,33 @@
+# Learn more about configuring your Customer account UI extension:
+# https://shopify.dev/api/customer-account-ui-extensions/2025-10/configuration
+
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "2025-10"
+
+[[extensions]]
+type = "ui_extension"
+name = "ca-loyalty-profile-block"
+handle = "ca-loyalty-profile-block"
+
+# Controls where in Shopify your extension will be injected,
+# and the file that contains your extension's source code. Learn more:
+# https://shopify.dev/docs/api/customer-account-ui-extensions/2025-10/extension-targets-overview
+
+# [START config.setup-targets]
+
+[[extensions.targeting]]
+module = "./src/ProfileBlockExtension.jsx"
+target = "customer-account.profile.block.render"
+
+# [END config.setup-targets]
+
+[extensions.capabilities]
+# Gives your extension access to directly query Shopify's storefront API.
+# https://shopify.dev/docs/api/customer-account-ui-extensions/2025-10/configuration#api-access
+api_access = true
+
+# Gives your extension access to make external network calls, using the
+# JavaScript `fetch()` API. Learn more:
+# https://shopify.dev/docs/api/customer-account-ui-extensions/2025-10/configuration#network-access
+# network_access = true

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/src/ProfileBlockExtension.jsx
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/src/ProfileBlockExtension.jsx
@@ -1,0 +1,44 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<ProfileBlockExtension />, document.body);
+};
+
+// [START profile.build-ui]
+function ProfileBlockExtension() {
+  const i18n = shopify.i18n;
+
+  return (
+    <s-section heading="Rewards">
+      <s-stack direction="block" gap="base" paddingBlockStart="base">
+        <s-grid gridTemplateColumns="1fr 1fr 1fr 1fr" gap="large">
+          <s-stack direction="block" gap="small">
+            <s-text color="subdued">Points</s-text>
+            <s-text type="strong">43,000</s-text>
+          </s-stack>
+          <s-stack direction="block" gap="small">
+            <s-text color="subdued">Store credit</s-text>
+            <s-text type="strong">
+              {i18n.formatCurrency(450, {currency: 'USD'})}
+            </s-text>
+          </s-stack>
+          <s-stack direction="block" gap="small">
+            <s-text color="subdued">Referrals</s-text>
+            <s-text type="strong">3</s-text>
+          </s-stack>
+          <s-stack direction="block" gap="small">
+            <s-text color="subdued">Referral bonus</s-text>
+            <s-text type="strong">600</s-text>
+          </s-stack>
+        </s-grid>
+        <s-stack direction="block" max-inline-size="140">
+          <s-button tone="neutral" variant="secondary">
+            View rewards
+          </s-button>
+        </s-stack>
+      </s-stack>
+    </s-section>
+  );
+}
+// [END profile.build-ui]

--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/tsconfig.json
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-profile-block/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true
+  }
+}


### PR DESCRIPTION
Closes https://github.com/shop/issues-checkout/issues/7751

Migrate the loyalty profile block extension example to preact. Based on this [extension](https://github.com/Shopify/customer-account-tutorials/blob/16f5f12ac8ac106282814a4b6cea7b26f24bb232/react/example-customer-account--loyalty-app--react/extensions/customer-account-loyalty-extension-profile/src/ProfileBlockExtension.tsx)

Here it is rendering in customer accounts: 

<img width="1188" height="305" alt="Screenshot 2025-09-09 at 2 00 40 PM" src="https://github.com/user-attachments/assets/e1fc78a3-54d8-4db3-bb46-0abe33a00e8a" />