### PR TITLE
Add preact version of wishlist app and profile block extension

### DIFF
--- a/preact/example-customer-account--wishlist--preact/.gitignore
+++ b/preact/example-customer-account--wishlist--preact/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/extensions/**/dist
+.DS_Store

--- a/preact/example-customer-account--wishlist--preact/.graphqlrc.js
+++ b/preact/example-customer-account--wishlist--preact/.graphqlrc.js
@@ -1,0 +1,30 @@
+const fs = require("node:fs");
+
+function getConfig() {
+  const config = {
+    projects: {},
+  };
+
+  let extensions = [];
+  try {
+    extensions = fs.readdirSync("./extensions");
+  } catch {
+    // ignore if no extensions
+  }
+
+  for (const entry of extensions) {
+    const extensionPath = `./extensions/${entry}`;
+    const schema = `${extensionPath}/schema.graphql`;
+    if (!fs.existsSync(schema)) {
+      continue;
+    }
+    config.projects[entry] = {
+      schema,
+      documents: [`${extensionPath}/**/*.graphql`],
+    };
+  }
+
+  return config;
+}
+
+module.exports = getConfig();

--- a/preact/example-customer-account--wishlist--preact/.npmrc
+++ b/preact/example-customer-account--wishlist--preact/.npmrc
@@ -1,0 +1,4 @@
+engine-strict=true
+auto-install-peers=true
+shamefully-hoist=true
+@shopify:registry=https://registry.npmjs.org

--- a/preact/example-customer-account--wishlist--preact/.vscode/extensions.json
+++ b/preact/example-customer-account--wishlist--preact/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "graphql.vscode-graphql"
+  ]
+}

--- a/preact/example-customer-account--wishlist--preact/README.md
+++ b/preact/example-customer-account--wishlist--preact/README.md
@@ -1,0 +1,78 @@
+# Shopify App Template - Extension only
+
+This is a template for building an [extension-only Shopify app](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app). It contains the basics for building a Shopify app that uses only app extensions.
+
+This template doesn't include a server or the ability to embed a page in the Shopify Admin. If you want either of these capabilities, choose the [Remix app template](https://github.com/Shopify/shopify-app-template-remix) instead.
+
+Whether you choose to use this template or another one, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template).
+
+## Benefits
+
+Shopify apps are built on a variety of Shopify tools to create a great merchant experience. The [create an app](https://shopify.dev/docs/apps/getting-started/create) tutorial in our developer documentation will guide you through creating a Shopify app.
+
+This app template does little more than install the CLI and scaffold a repository.
+
+## Getting started
+
+### Requirements
+
+1. You must [download and install Node.js](https://nodejs.org/en/download/) if you don't already have it.
+1. You must [create a Shopify partner account](https://partners.shopify.com/signup) if you don’t have one.
+1. You must create a store for testing if you don't have one, either a [development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) or a [Shopify Plus sandbox store](https://help.shopify.com/en/partners/dashboard/managing-stores/plus-sandbox-store).
+
+### Installing the template
+
+This template can be installed using your preferred package manager:
+
+Using yarn:
+
+```shell
+yarn create @shopify/app
+```
+
+Using npm:
+
+```shell
+npm init @shopify/app@latest
+```
+
+Using pnpm:
+
+```shell
+pnpm create @shopify/app@latest
+```
+
+This will clone the template and install the required dependencies.
+
+#### Local Development
+
+[The Shopify CLI](https://shopify.dev/docs/apps/tools/cli) connects to an app in your Partners dashboard. It provides environment variables and runs commands in parallel.
+
+You can develop locally using your preferred package manager. Run one of the following commands from the root of your app.
+
+Using yarn:
+
+```shell
+yarn dev
+```
+
+Using npm:
+
+```shell
+npm run dev
+```
+
+Using pnpm:
+
+```shell
+pnpm run dev
+```
+
+Open the URL generated in your console. Once you grant permission to the app, you can start development (such as generating extensions).
+
+## Developer resources
+
+- [Introduction to Shopify apps](https://shopify.dev/docs/apps/getting-started)
+- [App extensions](https://shopify.dev/docs/apps/build/app-extensions)
+- [Extension only apps](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app)
+- [Shopify CLI](https://shopify.dev/docs/apps/tools/cli)

--- a/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/README.md
+++ b/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/README.md
@@ -1,0 +1,21 @@
+# Customer account UI Extension
+
+## Prerequisites
+
+Before you start building your extension, make sure that you've created a [development store](https://shopify.dev/docs/apps/tools/development-stores) with the [Checkout and Customer Accounts Extensibility](https://shopify.dev/docs/api/release-notes/developer-previews#previewing-new-features).
+
+## Your new Extension
+
+Your new extension contains the following files:
+
+- `README.md`, the file you are reading right now.
+- `shopify.extension.toml`, the configuration file for your extension. This file defines your extension's name.
+- `src/*.jsx`, the source code for your extension.
+- `locales/en.default.json` and `locales/fr.json`, which contain translations used to [localized your extension](https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions).
+
+## Useful Links
+
+- [Customer account UI extension documentation](https://shopify.dev/docs/api/customer-account-ui-extensions)
+  - [Configuration](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/configuration)
+  - [API Reference](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis)
+  - [UI Components](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/components)

--- a/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/package.json
+++ b/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "wishlist-profile-block",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/shopify.d.ts
+++ b/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/shopify.d.ts
@@ -1,0 +1,7 @@
+import '@shopify/ui-extensions';
+
+//@ts-ignore
+declare module './src/ProfileBlockExtension.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.profile.block.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}

--- a/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/shopify.extension.toml
+++ b/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/shopify.extension.toml
@@ -1,0 +1,30 @@
+# Learn more about configuring your Customer account UI extension:
+# https://shopify.dev/api/customer-account-ui-extensions/2025-10/configuration
+
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "2025-10"
+
+[[extensions]]
+type = "ui_extension"
+name = "Upsell banner"
+handle = "wishlist-profile-block"
+
+# Controls where in Shopify your extension will be injected,
+# and the file that contains your extension's source code. Learn more:
+# https://shopify.dev/docs/api/customer-account-ui-extensions/2025-10/extension-targets-overview
+# [START config.setup-targets]
+[[extensions.targeting]]
+module = "./src/ProfileBlockExtension.jsx"
+target = "customer-account.profile.block.render"
+# [END config.setup-targets]
+
+[extensions.capabilities]
+# Gives your extension access to directly query Shopify's storefront API.
+# https://shopify.dev/docs/api/customer-account-ui-extensions/2025-10/configuration#api-access
+api_access = true
+
+# Gives your extension access to make external network calls, using the
+# JavaScript `fetch()` API. Learn more:
+# https://shopify.dev/docs/api/customer-account-ui-extensions/2025-10/configuration#network-access
+# network_access = true

--- a/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/src/ProfileBlockExtension.jsx
+++ b/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/src/ProfileBlockExtension.jsx
@@ -1,0 +1,21 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+// [START block.build-ui]
+export default async () => {
+  render(<BlockExtension />, document.body);
+};
+
+function BlockExtension() {
+  return (
+    <s-section>
+      <s-stack direction="inline" inline-alignment="center" gap="small-400">
+        <s-text>Grow your garden with more plants from your wishlist.</s-text>
+        <s-link href="extension:wishlist-extension-preact/">
+          View wishlist
+        </s-link>
+      </s-stack>
+    </s-section>
+  );
+}
+// [END block.build-ui]

--- a/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/tsconfig.json
+++ b/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true
+  }
+}

--- a/preact/example-customer-account--wishlist--preact/package.json
+++ b/preact/example-customer-account--wishlist--preact/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "customer-account-wishlist-app--preact",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "scripts": {
+    "shopify": "shopify",
+    "build": "shopify app build",
+    "dev": "shopify app dev",
+    "info": "shopify app info",
+    "generate": "shopify app generate",
+    "deploy": "shopify app deploy"
+  },
+  "dependencies": {},
+  "trustedDependencies": [
+    "@shopify/plugin-cloudflare"
+  ],
+  "private": true,
+  "workspaces": [
+    "extensions/*"
+  ]
+}


### PR DESCRIPTION
Starts https://github.com/shop/issues-checkout/issues/7755

Create Preact version of the wishlist app and it's first extension, the profile block extension. Most of this PR is boilerplate generated by the CLI.

Here is the extension rendering in customer accounts: 

<img width="1166" height="247" alt="Screenshot 2025-09-09 at 3 07 25 PM" src="https://github.com/user-attachments/assets/3abcca9a-9938-4003-9a63-3c9ab77a51af" />
