### PR TITLE
Add preact wishlist fullpage extension and editor extension collection 

### DIFF
--- a/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/README.md
+++ b/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/README.md
@@ -1,0 +1,21 @@
+# Customer account UI Extension
+
+## Prerequisites
+
+Before you start building your extension, make sure that you've created a [development store](https://shopify.dev/docs/apps/tools/development-stores) with the [Checkout and Customer Accounts Extensibility](https://shopify.dev/docs/api/release-notes/developer-previews#previewing-new-features).
+
+## Your new Extension
+
+Your new extension contains the following files:
+
+- `README.md`, the file you are reading right now.
+- `shopify.extension.toml`, the configuration file for your extension. This file defines your extension's name.
+- `src/*.jsx`, the source code for your extension.
+- `locales/en.default.json` and `locales/fr.json`, which contain translations used to [localized your extension](https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions).
+
+## Useful Links
+
+- [Customer account UI extension documentation](https://shopify.dev/docs/api/customer-account-ui-extensions)
+  - [Configuration](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/configuration)
+  - [API Reference](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis)
+  - [UI Components](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/components)

--- a/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/package.json
+++ b/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "customer-account-wishlist-extension",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/shopify.d.ts
+++ b/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/shopify.d.ts
@@ -1,0 +1,7 @@
+import '@shopify/ui-extensions';
+
+//@ts-ignore
+declare module './src/FullPageExtension.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.page.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}

--- a/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/shopify.extension.toml
+++ b/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/shopify.extension.toml
@@ -1,0 +1,18 @@
+api_version = "2025-10"
+
+[[extensions]]
+uid = "3a495b4c-7432-f824-50b6-44ec8381c25e7d2a5779"
+type = "ui_extension"
+name = "My wishlist"
+handle = "wishlist-extension-preact"
+
+# [START config.setup-targets]
+[[extensions.targeting]]
+module = "./src/FullPageExtension.jsx"
+target = "customer-account.page.render"
+# [END config.setup-targets]
+
+# [START config.api-access]
+[extensions.capabilities]
+api_access = true
+# [END config.api-access]

--- a/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/src/FullPageExtension.jsx
+++ b/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/src/FullPageExtension.jsx
@@ -1,0 +1,128 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+import {useEffect, useState} from 'preact/hooks';
+
+// [START full-page.setup-target]
+export default async () => {
+  render(<FullPageExtension />, document.body);
+};
+// [END full-page.setup-target]
+
+function FullPageExtension() {
+  const [wishlist, setWishlist] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [removeLoading, setRemoveLoading] = useState({
+    id: null,
+    loading: false,
+  });
+
+  // [START full-page.fetch-wishlist]
+  async function fetchWishlist() {
+    setLoading(true);
+
+    try {
+      // Implement a server request to retrieve the wishlist for this customer
+      // Then call the Storefront API to retrieve the details of the wishlisted products
+      const data = await shopify.query(
+        `query ($first: Int!) {
+          products(first: $first) {
+            nodes {
+              id
+              title
+              onlineStoreUrl
+              priceRange {
+                minVariantPrice {
+                  amount
+                  currencyCode
+                }
+              }
+              featuredImage {
+                url
+              }
+            }
+          }
+        }`,
+        {
+          variables: {first: 10},
+        }
+      );
+      setLoading(false);
+      setWishlist(data.data?.products?.nodes || []);
+    } catch (error) {
+      setLoading(false);
+      console.log(error);
+    }
+  }
+  // [END full-page.fetch-wishlist]
+
+  // [START full-page.delete-item]
+  async function deleteWishlistItem(id) {
+    // Simulate a server request
+    setRemoveLoading({loading: true, id});
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        // Send a request to your server to delete the wishlist item
+        setWishlist(wishlist.filter((item) => item.id !== id));
+
+        setRemoveLoading({loading: false, id: null});
+        resolve();
+      }, 750);
+    });
+  }
+  // [END full-page.delete-item]
+
+  // [START full-page.fetch-wishlist]
+  useEffect(() => {
+    fetchWishlist();
+  }, []);
+  // [END full-page.fetch-wishlist]
+
+  // [START full-page.build-ui]
+  return (
+    <s-page heading="Wishlist">
+      <s-grid gridTemplateColumns="1fr 1fr 1fr" gap="base">
+        {!loading &&
+          wishlist.length > 0 &&
+          wishlist.map((product) => {
+            return (
+              <s-section key={product.id}>
+                <s-stack direction="block" gap="base" paddingBlockEnd="large">
+                  <s-image src={product.featuredImage.url} />
+                  <s-stack direction="block" gap="small-500">
+                    <s-text color="subdued">{product.title}</s-text>
+                    <s-text type="strong">
+                      {shopify.i18n.formatCurrency(
+                        product.priceRange.minVariantPrice.amount,
+                        {
+                          currency:
+                            product.priceRange.minVariantPrice.currencyCode,
+                        }
+                      )}
+                    </s-text>
+                  </s-stack>
+                </s-stack>
+                <s-button slot="primary-action" href={product.onlineStoreUrl}>
+                  View product
+                </s-button>
+                <s-button
+                  slot="secondary-actions"
+                  loading={
+                    removeLoading.loading && product.id === removeLoading.id
+                  }
+                  onClick={() => {
+                    deleteWishlistItem(product.id);
+                  }}
+                >
+                  Remove
+                </s-button>
+              </s-section>
+            );
+          })}
+        {!loading && wishlist.length === 0 && (
+          <s-text>No items in your wishlist.</s-text>
+        )}
+      </s-grid>
+    </s-page>
+  );
+  // [END full-page.build-ui]
+}

--- a/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/tsconfig.json
+++ b/preact/example-customer-account--wishlist--preact/extensions/customer-account-wishlist-extension/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true
+  }
+}

--- a/preact/example-customer-account--wishlist--preact/extensions/editor-extension-collection/locales/en.default.json
+++ b/preact/example-customer-account--wishlist--preact/extensions/editor-extension-collection/locales/en.default.json
@@ -1,0 +1,3 @@
+{
+  "collection_name": "Wishlist management"
+}

--- a/preact/example-customer-account--wishlist--preact/extensions/editor-extension-collection/locales/fr.json
+++ b/preact/example-customer-account--wishlist--preact/extensions/editor-extension-collection/locales/fr.json
@@ -1,0 +1,3 @@
+{
+  "collection_name": "Wishlist management"
+}

--- a/preact/example-customer-account--wishlist--preact/extensions/editor-extension-collection/shopify.extension.toml
+++ b/preact/example-customer-account--wishlist--preact/extensions/editor-extension-collection/shopify.extension.toml
@@ -1,0 +1,21 @@
+# [START config.setup-collection-details]
+[[extensions]]
+name = "t:collection_name"
+uid = "aff2d787-08fb-5b20-9ff8-08f1d91dda8c86f44aa3"
+type = "editor_extension_collection"
+handle = "wishlist-management"
+# [END config.setup-collection-details]
+# Add the handles of the extensions you want in this collection here
+# [START config.setup-includes]
+includes=["wishlist-extension-preact", "wishlist-profile-block"]
+# [END config.setup-includes]
+# You can also add extensions to the collection this way
+#[[extensions.include]]
+#handle=""
+
+# A second editor extension collection added in the same extension toml config
+# [[extensions]]
+# name = "t:collection_two_name"
+# type = "editor_extension_collection"
+# handle = "editor-extension-collection"
+# includes=[]

--- a/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/shopify.extension.toml
+++ b/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/shopify.extension.toml
@@ -6,6 +6,7 @@
 api_version = "2025-10"
 
 [[extensions]]
+uid = "a1eb23c4-ce29-1e17-8061-132bf7a545b9d9bca54d"
 type = "ui_extension"
 name = "Upsell banner"
 handle = "wishlist-profile-block"

--- a/react/example-customer-account--wishlist--react/extensions/customer-account-wishlist-extension/src/FullPageExtension.tsx
+++ b/react/example-customer-account--wishlist--react/extensions/customer-account-wishlist-extension/src/FullPageExtension.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import {useEffect, useState} from 'react';
 import {
   reactExtension,
   useApi,
@@ -7,25 +7,24 @@ import {
   TextBlock,
   Button,
   Image,
-  Page, 
+  Page,
   ResourceItem,
   SkeletonImage,
   SkeletonText,
-} from "@shopify/ui-extensions-react/customer-account";
+} from '@shopify/ui-extensions-react/customer-account';
 
 // [START full-page.setup-target]
-export default reactExtension(
-  "customer-account.page.render",
-  () => <FullPageExtension />
-);
+export default reactExtension('customer-account.page.render', () => (
+  <FullPageExtension />
+));
 // [END full-page.setup-target]
-interface Product { 
+interface Product {
   id: string;
   title: string;
   onlineStoreUrl: string;
   featuredImage: {
     url: string;
-  }
+  };
   priceRange: {
     minVariantPrice: {
       amount: number;
@@ -39,10 +38,13 @@ interface Product {
 }
 
 function FullPageExtension() {
-  const { i18n, query } = useApi<"customer-account.page.render">();
-  const [wishlist, setWishlist] = useState<Product[]>([])
-  const [loading, setLoading] = useState(false)
-  const [removeLoading, setRemoveLoading] = useState({id: null, loading: false})
+  const {i18n, query} = useApi<'customer-account.page.render'>();
+  const [wishlist, setWishlist] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [removeLoading, setRemoveLoading] = useState({
+    id: null,
+    loading: false,
+  });
 
   // [START full-page.fetch-wishlist]
   async function fetchWishlist() {
@@ -51,7 +53,7 @@ function FullPageExtension() {
     try {
       // Implement a server request to retrieve the wishlist for this customer
       // Then call the Storefront API to retrieve the details of the wishlisted products
-      const data = await query<{ products: { nodes: Product[] }}>(
+      const data = await query<{products: {nodes: Product[]}}>(
         `query ($first: Int!) {
           products(first: $first) {
             nodes {
@@ -76,13 +78,13 @@ function FullPageExtension() {
         }`,
         {
           variables: {first: 10},
-        },
+        }
       );
       setLoading(false);
-      setWishlist(data.data?.products?.nodes || [])
+      setWishlist(data.data?.products?.nodes || []);
     } catch (error) {
       setLoading(false);
-      console.log(error)
+      console.log(error);
     }
   }
   // [END full-page.fetch-wishlist]
@@ -93,70 +95,88 @@ function FullPageExtension() {
     setRemoveLoading({loading: true, id});
     return new Promise<void>((resolve) => {
       setTimeout(() => {
+        // Send a request to your server to delete the wishlist item
+        setWishlist(wishlist.filter((item) => item.id !== id));
 
-      // Send a request to your server to delete the wishlist item
-      setWishlist(wishlist.filter((item) => item.id !== id))
-
-      setRemoveLoading({loading: false, id: null});
-      resolve();
-    }, 750)});
+        setRemoveLoading({loading: false, id: null});
+        resolve();
+      }, 750);
+    });
   }
   // [END full-page.delete-item]
 
   // [START full-page.fetch-wishlist]
   useEffect(() => {
     fetchWishlist();
-  }, [])
+  }, []);
   // [END full-page.fetch-wishlist]
 
   // [START full-page.build-ui]
   return (
-  <Page title="Wishlist">
-    <Grid columns={['fill', 'fill', 'fill']} rows="auto" spacing="loose">
-      {loading && <ResourceItem loading>
-        <BlockStack spacing="base">
-          <SkeletonImage inlineSize="fill" aspectRatio={1} blockSize="fill" />
-          <BlockStack spacing="none">
-            <SkeletonText inlineSize="base" />
-          </BlockStack>
-          <SkeletonText inlineSize="small" />
-        </BlockStack>
-      </ResourceItem>}
-      {!loading && wishlist.length > 0 && wishlist.map((product) => {
-          return (
-            <ResourceItem loading={loading} key={product.id} action={
-              <>
-                <Button
-                  kind='primary'
-                  to={product.onlineStoreUrl}
-                >
-                  View product
-                </Button>
-                <Button
-                  kind='secondary'
-                  loading={removeLoading.loading && product.id === removeLoading.id}
-                  onPress={() => {
-                    deleteWishlistItem(product.id)
-                  }}
-                >
-                  Remove
-                </Button>
-              </>
-            }>
-              <BlockStack spacing="base">
-              <Image source={product.featuredImage.url}></Image>
-              <TextBlock emphasis="bold">{product.title}</TextBlock>
-              <TextBlock appearance="subdued">
-              {i18n.formatCurrency(product.priceRange.minVariantPrice.amount, {currency: product.priceRange.minVariantPrice.currencyCode})}
-              </TextBlock>
+    <Page title="Wishlist">
+      <Grid columns={['fill', 'fill', 'fill']} rows="auto" spacing="loose">
+        {loading && (
+          <ResourceItem loading>
+            <BlockStack spacing="base">
+              <SkeletonImage
+                inlineSize="fill"
+                aspectRatio={1}
+                blockSize="fill"
+              />
+              <BlockStack spacing="none">
+                <SkeletonText inlineSize="base" />
               </BlockStack>
-            </ResourceItem>
-          )
-        })
-      }
-      {!loading && wishlist.length === 0 && <TextBlock>No items in your wishlist.</TextBlock>}
+              <SkeletonText inlineSize="small" />
+            </BlockStack>
+          </ResourceItem>
+        )}
+        {!loading &&
+          wishlist.length > 0 &&
+          wishlist.map((product) => {
+            return (
+              <ResourceItem
+                loading={loading}
+                key={product.id}
+                action={
+                  <>
+                    <Button kind="primary" to={product.onlineStoreUrl}>
+                      View product
+                    </Button>
+                    <Button
+                      kind="secondary"
+                      loading={
+                        removeLoading.loading && product.id === removeLoading.id
+                      }
+                      onPress={() => {
+                        deleteWishlistItem(product.id);
+                      }}
+                    >
+                      Remove
+                    </Button>
+                  </>
+                }
+              >
+                <BlockStack spacing="base">
+                  <Image source={product.featuredImage.url}></Image>
+                  <TextBlock emphasis="bold">{product.title}</TextBlock>
+                  <TextBlock appearance="subdued">
+                    {i18n.formatCurrency(
+                      product.priceRange.minVariantPrice.amount,
+                      {
+                        currency:
+                          product.priceRange.minVariantPrice.currencyCode,
+                      }
+                    )}
+                  </TextBlock>
+                </BlockStack>
+              </ResourceItem>
+            );
+          })}
+        {!loading && wishlist.length === 0 && (
+          <TextBlock>No items in your wishlist.</TextBlock>
+        )}
       </Grid>
-  </Page>
+    </Page>
   );
   // [END full-page.build-ui]
 }

--- a/react/example-customer-account--wishlist--react/extensions/customer-account-wishlist-extension/src/FullPageExtension.tsx
+++ b/react/example-customer-account--wishlist--react/extensions/customer-account-wishlist-extension/src/FullPageExtension.tsx
@@ -1,4 +1,4 @@
-import {useEffect, useState} from 'react';
+import { useEffect, useState } from 'react'
 import {
   reactExtension,
   useApi,
@@ -7,24 +7,25 @@ import {
   TextBlock,
   Button,
   Image,
-  Page,
+  Page, 
   ResourceItem,
   SkeletonImage,
   SkeletonText,
-} from '@shopify/ui-extensions-react/customer-account';
+} from "@shopify/ui-extensions-react/customer-account";
 
 // [START full-page.setup-target]
-export default reactExtension('customer-account.page.render', () => (
-  <FullPageExtension />
-));
+export default reactExtension(
+  "customer-account.page.render",
+  () => <FullPageExtension />
+);
 // [END full-page.setup-target]
-interface Product {
+interface Product { 
   id: string;
   title: string;
   onlineStoreUrl: string;
   featuredImage: {
     url: string;
-  };
+  }
   priceRange: {
     minVariantPrice: {
       amount: number;
@@ -38,13 +39,10 @@ interface Product {
 }
 
 function FullPageExtension() {
-  const {i18n, query} = useApi<'customer-account.page.render'>();
-  const [wishlist, setWishlist] = useState<Product[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [removeLoading, setRemoveLoading] = useState({
-    id: null,
-    loading: false,
-  });
+  const { i18n, query } = useApi<"customer-account.page.render">();
+  const [wishlist, setWishlist] = useState<Product[]>([])
+  const [loading, setLoading] = useState(false)
+  const [removeLoading, setRemoveLoading] = useState({id: null, loading: false})
 
   // [START full-page.fetch-wishlist]
   async function fetchWishlist() {
@@ -53,7 +51,7 @@ function FullPageExtension() {
     try {
       // Implement a server request to retrieve the wishlist for this customer
       // Then call the Storefront API to retrieve the details of the wishlisted products
-      const data = await query<{products: {nodes: Product[]}}>(
+      const data = await query<{ products: { nodes: Product[] }}>(
         `query ($first: Int!) {
           products(first: $first) {
             nodes {
@@ -78,13 +76,13 @@ function FullPageExtension() {
         }`,
         {
           variables: {first: 10},
-        }
+        },
       );
       setLoading(false);
-      setWishlist(data.data?.products?.nodes || []);
+      setWishlist(data.data?.products?.nodes || [])
     } catch (error) {
       setLoading(false);
-      console.log(error);
+      console.log(error)
     }
   }
   // [END full-page.fetch-wishlist]
@@ -95,88 +93,70 @@ function FullPageExtension() {
     setRemoveLoading({loading: true, id});
     return new Promise<void>((resolve) => {
       setTimeout(() => {
-        // Send a request to your server to delete the wishlist item
-        setWishlist(wishlist.filter((item) => item.id !== id));
 
-        setRemoveLoading({loading: false, id: null});
-        resolve();
-      }, 750);
-    });
+      // Send a request to your server to delete the wishlist item
+      setWishlist(wishlist.filter((item) => item.id !== id))
+
+      setRemoveLoading({loading: false, id: null});
+      resolve();
+    }, 750)});
   }
   // [END full-page.delete-item]
 
   // [START full-page.fetch-wishlist]
   useEffect(() => {
     fetchWishlist();
-  }, []);
+  }, [])
   // [END full-page.fetch-wishlist]
 
   // [START full-page.build-ui]
   return (
-    <Page title="Wishlist">
-      <Grid columns={['fill', 'fill', 'fill']} rows="auto" spacing="loose">
-        {loading && (
-          <ResourceItem loading>
-            <BlockStack spacing="base">
-              <SkeletonImage
-                inlineSize="fill"
-                aspectRatio={1}
-                blockSize="fill"
-              />
-              <BlockStack spacing="none">
-                <SkeletonText inlineSize="base" />
+  <Page title="Wishlist">
+    <Grid columns={['fill', 'fill', 'fill']} rows="auto" spacing="loose">
+      {loading && <ResourceItem loading>
+        <BlockStack spacing="base">
+          <SkeletonImage inlineSize="fill" aspectRatio={1} blockSize="fill" />
+          <BlockStack spacing="none">
+            <SkeletonText inlineSize="base" />
+          </BlockStack>
+          <SkeletonText inlineSize="small" />
+        </BlockStack>
+      </ResourceItem>}
+      {!loading && wishlist.length > 0 && wishlist.map((product) => {
+          return (
+            <ResourceItem loading={loading} key={product.id} action={
+              <>
+                <Button
+                  kind='primary'
+                  to={product.onlineStoreUrl}
+                >
+                  View product
+                </Button>
+                <Button
+                  kind='secondary'
+                  loading={removeLoading.loading && product.id === removeLoading.id}
+                  onPress={() => {
+                    deleteWishlistItem(product.id)
+                  }}
+                >
+                  Remove
+                </Button>
+              </>
+            }>
+              <BlockStack spacing="base">
+              <Image source={product.featuredImage.url}></Image>
+              <TextBlock emphasis="bold">{product.title}</TextBlock>
+              <TextBlock appearance="subdued">
+              {i18n.formatCurrency(product.priceRange.minVariantPrice.amount, {currency: product.priceRange.minVariantPrice.currencyCode})}
+              </TextBlock>
               </BlockStack>
-              <SkeletonText inlineSize="small" />
-            </BlockStack>
-          </ResourceItem>
-        )}
-        {!loading &&
-          wishlist.length > 0 &&
-          wishlist.map((product) => {
-            return (
-              <ResourceItem
-                loading={loading}
-                key={product.id}
-                action={
-                  <>
-                    <Button kind="primary" to={product.onlineStoreUrl}>
-                      View product
-                    </Button>
-                    <Button
-                      kind="secondary"
-                      loading={
-                        removeLoading.loading && product.id === removeLoading.id
-                      }
-                      onPress={() => {
-                        deleteWishlistItem(product.id);
-                      }}
-                    >
-                      Remove
-                    </Button>
-                  </>
-                }
-              >
-                <BlockStack spacing="base">
-                  <Image source={product.featuredImage.url}></Image>
-                  <TextBlock emphasis="bold">{product.title}</TextBlock>
-                  <TextBlock appearance="subdued">
-                    {i18n.formatCurrency(
-                      product.priceRange.minVariantPrice.amount,
-                      {
-                        currency:
-                          product.priceRange.minVariantPrice.currencyCode,
-                      }
-                    )}
-                  </TextBlock>
-                </BlockStack>
-              </ResourceItem>
-            );
-          })}
-        {!loading && wishlist.length === 0 && (
-          <TextBlock>No items in your wishlist.</TextBlock>
-        )}
+            </ResourceItem>
+          )
+        })
+      }
+      {!loading && wishlist.length === 0 && <TextBlock>No items in your wishlist.</TextBlock>}
       </Grid>
-    </Page>
+  </Page>
   );
   // [END full-page.build-ui]
 }


### PR DESCRIPTION
Closes https://github.com/shop/issues-checkout/issues/7755

Migrates two more extensions to preact:

Wishlist full page: 

<img width="1152" height="718" alt="Screenshot 2025-09-10 at 2 04 31 PM" src="https://github.com/user-attachments/assets/2c5f5b58-c175-4938-8763-5ec233ebb843" />

Editor extension collection for wishlist app: 

<img width="335" height="203" alt="Screenshot 2025-09-10 at 2 22 05 PM" src="https://github.com/user-attachments/assets/c49459b0-8278-4cde-8a9c-bcadfd96bf48" />

For testing, it is probably easiest to drop the code from the full page extension into one of your own test apps: 

- Check that clicking the remove button removes the item from the list
- Check that when no items remain, an empty state appears