### PR TITLE
Migrate pre auth app example to preact

### DIFF
--- a/preact/example-customer-account--pre-auth--preact/.gitignore
+++ b/preact/example-customer-account--pre-auth--preact/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/extensions/**/dist
+.DS_Store

--- a/preact/example-customer-account--pre-auth--preact/.graphqlrc.js
+++ b/preact/example-customer-account--pre-auth--preact/.graphqlrc.js
@@ -1,0 +1,30 @@
+const fs = require("node:fs");
+
+function getConfig() {
+  const config = {
+    projects: {},
+  };
+
+  let extensions = [];
+  try {
+    extensions = fs.readdirSync("./extensions");
+  } catch {
+    // ignore if no extensions
+  }
+
+  for (const entry of extensions) {
+    const extensionPath = `./extensions/${entry}`;
+    const schema = `${extensionPath}/schema.graphql`;
+    if (!fs.existsSync(schema)) {
+      continue;
+    }
+    config.projects[entry] = {
+      schema,
+      documents: [`${extensionPath}/**/*.graphql`],
+    };
+  }
+
+  return config;
+}
+
+module.exports = getConfig();

--- a/preact/example-customer-account--pre-auth--preact/.npmrc
+++ b/preact/example-customer-account--pre-auth--preact/.npmrc
@@ -1,0 +1,4 @@
+engine-strict=true
+auto-install-peers=true
+shamefully-hoist=true
+@shopify:registry=https://registry.npmjs.org

--- a/preact/example-customer-account--pre-auth--preact/.vscode/extensions.json
+++ b/preact/example-customer-account--pre-auth--preact/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "graphql.vscode-graphql"
+  ]
+}

--- a/preact/example-customer-account--pre-auth--preact/README.md
+++ b/preact/example-customer-account--pre-auth--preact/README.md
@@ -1,0 +1,78 @@
+# Shopify App Template - Extension only
+
+This is a template for building an [extension-only Shopify app](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app). It contains the basics for building a Shopify app that uses only app extensions.
+
+This template doesn't include a server or the ability to embed a page in the Shopify Admin. If you want either of these capabilities, choose the [Remix app template](https://github.com/Shopify/shopify-app-template-remix) instead.
+
+Whether you choose to use this template or another one, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template).
+
+## Benefits
+
+Shopify apps are built on a variety of Shopify tools to create a great merchant experience. The [create an app](https://shopify.dev/docs/apps/getting-started/create) tutorial in our developer documentation will guide you through creating a Shopify app.
+
+This app template does little more than install the CLI and scaffold a repository.
+
+## Getting started
+
+### Requirements
+
+1. You must [download and install Node.js](https://nodejs.org/en/download/) if you don't already have it.
+1. You must [create a Shopify partner account](https://partners.shopify.com/signup) if you don’t have one.
+1. You must create a store for testing if you don't have one, either a [development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) or a [Shopify Plus sandbox store](https://help.shopify.com/en/partners/dashboard/managing-stores/plus-sandbox-store).
+
+### Installing the template
+
+This template can be installed using your preferred package manager:
+
+Using yarn:
+
+```shell
+yarn create @shopify/app
+```
+
+Using npm:
+
+```shell
+npm init @shopify/app@latest
+```
+
+Using pnpm:
+
+```shell
+pnpm create @shopify/app@latest
+```
+
+This will clone the template and install the required dependencies.
+
+#### Local Development
+
+[The Shopify CLI](https://shopify.dev/docs/apps/tools/cli) connects to an app in your Partners dashboard. It provides environment variables and runs commands in parallel.
+
+You can develop locally using your preferred package manager. Run one of the following commands from the root of your app.
+
+Using yarn:
+
+```shell
+yarn dev
+```
+
+Using npm:
+
+```shell
+npm run dev
+```
+
+Using pnpm:
+
+```shell
+pnpm run dev
+```
+
+Open the URL generated in your console. Once you grant permission to the app, you can start development (such as generating extensions).
+
+## Developer resources
+
+- [Introduction to Shopify apps](https://shopify.dev/docs/apps/getting-started)
+- [App extensions](https://shopify.dev/docs/apps/build/app-extensions)
+- [Extension only apps](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app)
+- [Shopify CLI](https://shopify.dev/docs/apps/tools/cli)

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/README.md
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/README.md
@@ -1,0 +1,21 @@
+# Customer account UI Extension
+
+## Prerequisites
+
+Before you start building your extension, make sure that you've created a [development store](https://shopify.dev/docs/apps/tools/development-stores) with the [Checkout and Customer Accounts Extensibility](https://shopify.dev/docs/api/release-notes/developer-previews#previewing-new-features).
+
+## Your new Extension
+
+Your new extension contains the following files:
+
+- `README.md`, the file you are reading right now.
+- `shopify.extension.toml`, the configuration file for your extension. This file defines your extension's name.
+- `src/*.jsx`, the source code for your extension.
+- `locales/en.default.json` and `locales/fr.json`, which contain translations used to [localized your extension](https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions).
+
+## Useful Links
+
+- [Customer account UI extension documentation](https://shopify.dev/docs/api/customer-account-ui-extensions)
+  - [Configuration](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/configuration)
+  - [API Reference](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis)
+  - [UI Components](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/components)

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/package.json
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "customer-account-pre-auth-loyalty",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/shopify.d.ts
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/shopify.d.ts
@@ -1,0 +1,7 @@
+import '@shopify/ui-extensions';
+
+//@ts-ignore
+declare module './src/BlockLoyaltyExtension.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.order-status.block.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/shopify.extension.toml
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/shopify.extension.toml
@@ -1,0 +1,16 @@
+api_version = "2025-10"
+
+[[extensions]]
+uid = "c96aa931-ed42-24ea-b5cf-289deff901edbd465085"
+type = "ui_extension"
+name = "customer-account-pre-auth-loyalty-preact"
+handle = "pre-auth-loyalty-extension-preact"
+
+# [START config.setup-targets]
+[[extensions.targeting]]
+module = "./src/BlockLoyaltyExtension.jsx"
+target = "customer-account.order-status.block.render"
+# [END config.setup-targets]
+
+[extensions.capabilities]
+# api_access = true

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/src/BlockLoyaltyExtension.jsx
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/src/BlockLoyaltyExtension.jsx
@@ -1,0 +1,42 @@
+
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<BlockLoyaltyExtension />, document.body);
+};
+
+// [START order-status-block.render-card]
+function BlockLoyaltyExtension() {
+  
+  // [START order-status-block.require-login]
+  async function viewPoints() {
+    await shopify.requireLogin();
+  }
+  // [END order-status-block.require-login]
+
+  // [START order-status-block.check-authentication-state]
+  const authenticationState = shopify.authenticationState.value;
+  // [END order-status-block.check-authentication-state]
+  
+  return (
+    <s-section>
+      <s-stack direction="inline" inline-alignment="center" gap="small-500">
+        <s-text>Points earned from your purchase: </s-text>
+        { 
+          authenticationState === 'pre_authenticated' ? 
+            // [START order-status-block.pre-authenticated-content]
+            <s-link onClick={viewPoints} tone="neutral">
+              View rewards
+            </s-link>
+            // [END order-status-block.pre-authenticated-content]
+            : 
+            // [START order-status-block.fully-authenticated-content]
+            <s-text>560</s-text>
+            // [END order-status-block.fully-authenticated-content]
+        }
+      </s-stack>
+    </s-section>
+  );
+}
+// [END order-status-block.render-card] 

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/tsconfig.json
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-loyalty/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true
+  }
+}

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/README.md
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/README.md
@@ -1,0 +1,21 @@
+# Customer account UI Extension
+
+## Prerequisites
+
+Before you start building your extension, make sure that you've created a [development store](https://shopify.dev/docs/apps/tools/development-stores) with the [Checkout and Customer Accounts Extensibility](https://shopify.dev/docs/api/release-notes/developer-previews#previewing-new-features).
+
+## Your new Extension
+
+Your new extension contains the following files:
+
+- `README.md`, the file you are reading right now.
+- `shopify.extension.toml`, the configuration file for your extension. This file defines your extension's name.
+- `src/*.jsx`, the source code for your extension.
+- `locales/en.default.json` and `locales/fr.json`, which contain translations used to [localized your extension](https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions).
+
+## Useful Links
+
+- [Customer account UI extension documentation](https://shopify.dev/docs/api/customer-account-ui-extensions)
+  - [Configuration](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/configuration)
+  - [API Reference](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis)
+  - [UI Components](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/components)

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/package.json
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "customer-account-pre-auth-note",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/shopify.d.ts
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/shopify.d.ts
@@ -1,0 +1,11 @@
+import '@shopify/ui-extensions';
+
+declare module './src/MenuActionItemButtonExtension.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.order.action.menu-item.render').Api;
+  const globalThis: {shopify: typeof shopify};
+}
+
+declare module './src/MenuActionModalExtension.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.order.action.render').Api;
+  const globalThis: {shopify: typeof shopify};
+}

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/shopify.extension.toml
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/shopify.extension.toml
@@ -1,0 +1,20 @@
+api_version = "2025-10"
+
+[[extensions]]
+uid = "1cf4f1a2-0def-235f-6508-aa91127c34065228f1d0"
+type = "ui_extension"
+name = "customer-account-pre-auth-note-preact"
+handle = "pre-auth-note-preact"
+
+# [START config.setup-targets]
+[[extensions.targeting]]
+module = "./src/MenuActionItemButtonExtension.jsx"
+target = "customer-account.order.action.menu-item.render"
+
+[[extensions.targeting]]
+module = "./src/MenuActionModalExtension.jsx"
+target = "customer-account.order.action.render"
+# [END config.setup-targets]
+
+[extensions.capabilities]
+# api_access = true

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/src/MenuActionItemButtonExtension.jsx
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/src/MenuActionItemButtonExtension.jsx
@@ -1,0 +1,12 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+
+export default async () => {
+  render(<MenuActionItemButtonExtension />, document.body);
+};
+
+// [START menu-action.render-button]
+function MenuActionItemButtonExtension() {
+  return <s-button>Add note</s-button>;
+}
+// [END menu-action.render-button]

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/src/MenuActionModalExtension.jsx
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/src/MenuActionModalExtension.jsx
@@ -1,0 +1,50 @@
+// [START menu-action-modal.render-modal]
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
+
+export default async () => {
+  render(<MenuActionModalExtension />, document.body);
+};
+
+function MenuActionModalExtension() {
+  const [note, setNote] = useState('');
+
+  function saveNote() {
+    try {
+      // [START menu-action-modal.make-request]
+      // make a request to the server to add a note
+      // [END menu-action-modal.make-request]
+      console.log(note);
+    } catch (error) {
+      console.log(error);
+    } finally {
+      shopify.close();
+    }
+  }
+
+  return (
+    <s-customer-account-action heading="Add a note to the order">
+      <s-stack direction="block">
+        <s-text-area
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+          label="Note for the order"
+        />
+      </s-stack>
+
+      <s-button slot="primary-action" type="submit" onClick={saveNote}>
+        Add note
+      </s-button>
+      <s-button
+        slot="secondary-actions"
+        onClick={() => shopify.close()}
+        variant="secondary"
+      >
+        Cancel
+      </s-button>
+    </s-customer-account-action>
+  );
+}
+// [END menu-action-modal.render-modal]

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/tsconfig.json
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true
+  }
+}

--- a/preact/example-customer-account--pre-auth--preact/package.json
+++ b/preact/example-customer-account--pre-auth--preact/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "customer-account-pre-auth--preact",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "scripts": {
+    "shopify": "shopify",
+    "build": "shopify app build",
+    "dev": "shopify app dev",
+    "info": "shopify app info",
+    "generate": "shopify app generate",
+    "deploy": "shopify app deploy"
+  },
+  "dependencies": {},
+  "trustedDependencies": [
+    "@shopify/plugin-cloudflare"
+  ],
+  "private": true,
+  "workspaces": [
+    "extensions/*"
+  ]
+}


### PR DESCRIPTION
Closes https://github.com/shop/issues-checkout/issues/7754

Migrates the pre-auth example app to preact. This pr includes the base app boilerplate, and both of the extensions included in this app. 

**Pre auth loyalty extension**

Renders in this state when the customer is not authed: 

<img width="403" height="92" alt="Screenshot 2025-09-10 at 4 31 43 PM" src="https://github.com/user-attachments/assets/7b12c6a1-2e5b-4822-81be-180139160e61" />

And this state when they are: 

<img width="394" height="124" alt="Screenshot 2025-09-10 at 4 32 00 PM" src="https://github.com/user-attachments/assets/d06f8d2d-e4e4-42d3-82cd-be2153581b31" />

I'd like to add better content for the pre auth state, but will do that in a future PR when I update the docs. 

**Add note extension**

Renders a menu item extension: 

<img width="405" height="240" alt="Screenshot 2025-09-10 at 5 05 21 PM" src="https://github.com/user-attachments/assets/a70745bc-c460-483a-86e8-a7ff0e646199" />

And a customer account action extension: 

<img width="700" height="272" alt="Screenshot 2025-09-10 at 4 47 39 PM" src="https://github.com/user-attachments/assets/e689cab2-f9b4-4637-99fe-d18730cc3afc" />