### PR TITLE
Migrate order action example app to Preact

### DIFF
--- a/preact/example-customer-account--order-action-menu--preact/.gitignore
+++ b/preact/example-customer-account--order-action-menu--preact/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/extensions/**/dist
+.DS_Store

--- a/preact/example-customer-account--order-action-menu--preact/.graphqlrc.js
+++ b/preact/example-customer-account--order-action-menu--preact/.graphqlrc.js
@@ -1,0 +1,30 @@
+const fs = require("node:fs");
+
+function getConfig() {
+  const config = {
+    projects: {},
+  };
+
+  let extensions = [];
+  try {
+    extensions = fs.readdirSync("./extensions");
+  } catch {
+    // ignore if no extensions
+  }
+
+  for (const entry of extensions) {
+    const extensionPath = `./extensions/${entry}`;
+    const schema = `${extensionPath}/schema.graphql`;
+    if (!fs.existsSync(schema)) {
+      continue;
+    }
+    config.projects[entry] = {
+      schema,
+      documents: [`${extensionPath}/**/*.graphql`],
+    };
+  }
+
+  return config;
+}
+
+module.exports = getConfig();

--- a/preact/example-customer-account--order-action-menu--preact/.npmrc
+++ b/preact/example-customer-account--order-action-menu--preact/.npmrc
@@ -1,0 +1,4 @@
+engine-strict=true
+auto-install-peers=true
+shamefully-hoist=true
+@shopify:registry=https://registry.npmjs.org

--- a/preact/example-customer-account--order-action-menu--preact/.vscode/extensions.json
+++ b/preact/example-customer-account--order-action-menu--preact/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+  "recommendations": [
+    "graphql.vscode-graphql"
+  ]
+}

--- a/preact/example-customer-account--order-action-menu--preact/README.md
+++ b/preact/example-customer-account--order-action-menu--preact/README.md
@@ -1,0 +1,78 @@
+# Shopify App Template - Extension only
+
+This is a template for building an [extension-only Shopify app](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app). It contains the basics for building a Shopify app that uses only app extensions.
+
+This template doesn't include a server or the ability to embed a page in the Shopify Admin. If you want either of these capabilities, choose the [Remix app template](https://github.com/Shopify/shopify-app-template-remix) instead.
+
+Whether you choose to use this template or another one, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template).
+
+## Benefits
+
+Shopify apps are built on a variety of Shopify tools to create a great merchant experience. The [create an app](https://shopify.dev/docs/apps/getting-started/create) tutorial in our developer documentation will guide you through creating a Shopify app.
+
+This app template does little more than install the CLI and scaffold a repository.
+
+## Getting started
+
+### Requirements
+
+1. You must [download and install Node.js](https://nodejs.org/en/download/) if you don't already have it.
+1. You must [create a Shopify partner account](https://partners.shopify.com/signup) if you don’t have one.
+1. You must create a store for testing if you don't have one, either a [development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) or a [Shopify Plus sandbox store](https://help.shopify.com/en/partners/dashboard/managing-stores/plus-sandbox-store).
+
+### Installing the template
+
+This template can be installed using your preferred package manager:
+
+Using yarn:
+
+```shell
+yarn create @shopify/app
+```
+
+Using npm:
+
+```shell
+npm init @shopify/app@latest
+```
+
+Using pnpm:
+
+```shell
+pnpm create @shopify/app@latest
+```
+
+This will clone the template and install the required dependencies.
+
+#### Local Development
+
+[The Shopify CLI](https://shopify.dev/docs/apps/tools/cli) connects to an app in your Partners dashboard. It provides environment variables and runs commands in parallel.
+
+You can develop locally using your preferred package manager. Run one of the following commands from the root of your app.
+
+Using yarn:
+
+```shell
+yarn dev
+```
+
+Using npm:
+
+```shell
+npm run dev
+```
+
+Using pnpm:
+
+```shell
+pnpm run dev
+```
+
+Open the URL generated in your console. Once you grant permission to the app, you can start development (such as generating extensions).
+
+## Developer resources
+
+- [Introduction to Shopify apps](https://shopify.dev/docs/apps/getting-started)
+- [App extensions](https://shopify.dev/docs/apps/build/app-extensions)
+- [Extension only apps](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app)
+- [Shopify CLI](https://shopify.dev/docs/apps/tools/cli)

--- a/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/README.md
+++ b/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/README.md
@@ -1,0 +1,21 @@
+# Customer account UI Extension
+
+## Prerequisites
+
+Before you start building your extension, make sure that you've created a [development store](https://shopify.dev/docs/apps/tools/development-stores) with the [Checkout and Customer Accounts Extensibility](https://shopify.dev/docs/api/release-notes/developer-previews#previewing-new-features).
+
+## Your new Extension
+
+Your new extension contains the following files:
+
+- `README.md`, the file you are reading right now.
+- `shopify.extension.toml`, the configuration file for your extension. This file defines your extension's name.
+- `src/*.jsx`, the source code for your extension.
+- `locales/en.default.json` and `locales/fr.json`, which contain translations used to [localized your extension](https://shopify.dev/docs/apps/checkout/best-practices/localizing-ui-extensions).
+
+## Useful Links
+
+- [Customer account UI extension documentation](https://shopify.dev/docs/api/customer-account-ui-extensions)
+  - [Configuration](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/configuration)
+  - [API Reference](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/apis)
+  - [UI Components](https://shopify.dev/docs/api/customer-account-ui-extensions/unstable/components)

--- a/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/package.json
+++ b/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "action-menu-extension-preact",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/shopify.d.ts
+++ b/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/shopify.d.ts
@@ -1,0 +1,13 @@
+import '@shopify/ui-extensions';
+
+//@ts-ignore
+declare module './src/MenuActionExtension.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.order.action.menu-item.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}
+
+//@ts-ignore
+declare module './src/MenuActionModalExtension.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.order.action.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}

--- a/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/shopify.extension.toml
+++ b/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/shopify.extension.toml
@@ -1,0 +1,17 @@
+api_version = "2025-10"
+
+[[extensions]]
+uid = "80e9f109-e0c9-ab13-2c5a-e065beb9d2eb669d1292"
+type = "ui_extension"
+name = "action-menu-extension-preact"
+handle = "action-menu-extension-preact"
+
+# [START config.setup-targets]
+[[extensions.targeting]]
+module = "./src/MenuActionExtension.jsx"
+target = "customer-account.order.action.menu-item.render"
+
+[[extensions.targeting]]
+module = "./src/MenuActionModalExtension.jsx"
+target = "customer-account.order.action.render"
+# [END config.setup-targets]

--- a/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/src/MenuActionExtension.jsx
+++ b/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/src/MenuActionExtension.jsx
@@ -1,0 +1,55 @@
+import {render} from 'preact';
+
+// [START menu-action.setup-target]
+export default async () => {
+  // [START menu-action.fetch-order-fulfillments]
+  let hasFulfillments = false;
+
+  try {
+    const orderQuery = {
+      query: `query Order($orderId: ID!) {
+        order(id: $orderId) {
+          fulfillments(first: 1) {
+            nodes {
+              latestShipmentStatus
+            }
+          }
+        }
+      }`,
+      variables: {orderId: shopify.orderId},
+    };
+
+    const result = await fetch(
+      'shopify://customer-account/api/2025-10/graphql.json',
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(orderQuery),
+      }
+    );
+
+    const {data} = await result.json();
+
+    hasFulfillments = data.order.fulfillments.nodes.length !== 0;
+  } catch (error) {
+    console.log(error);
+    hasFulfillments = false;
+  }
+  render(<MenuActionExtension showAction={hasFulfillments} />, document.body);
+  // [END menu-action.fetch-order-fulfillments]
+};
+// [END menu-action.setup-target]
+
+function MenuActionExtension({showAction}) {
+  // [START menu-action.conditionally-render]
+  if (!showAction) {
+    return null;
+  }
+  // [END menu-action.conditionally-render]
+
+  // [START menu-action.render-button]
+  return <s-button>Report a problem</s-button>;
+  // [END menu-action.render-button]
+}

--- a/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/src/MenuActionModalExtension.jsx
+++ b/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/src/MenuActionModalExtension.jsx
@@ -1,0 +1,78 @@
+import '@shopify/ui-extensions/preact';
+import {render} from 'preact';
+import {useState} from 'preact/hooks';
+
+export default async () => {
+  render(<MenuActionModalExtension />, document.body);
+};
+
+const dtcOptions = [
+  {value: '1', label: 'Package item is damaged'},
+  {value: '2', label: 'Missing items'},
+  {value: '3', label: 'Wrong item was sent'},
+  {value: '4', label: 'Item arrived too late'},
+  {value: '5', label: 'Never received item'},
+];
+
+// [START menu-action-modal.b2b-check]
+const b2bOptions = dtcOptions.concat([
+  {value: '6', label: 'Package sent to the wrong company location'},
+]);
+// [END menu-action-modal.b2b-check]
+
+function MenuActionModalExtension() {
+  const [currentProblem, setCurrentProblem] = useState('1');
+  const [isLoading, setIsLoading] = useState(false);
+
+  // [START menu-action-modal.b2b-check]
+  const isB2BCustomer =
+    shopify.authenticatedAccount.purchasingCompany.value != null;
+  // [END menu-action-modal.b2b-check]
+
+  // [START menu-action-modal.on-submit]
+  function onSubmit() {
+    // Simulating a request to your server to store the reported problem
+    setIsLoading(true);
+
+    console.log('Problem reported: ', currentProblem);
+
+    setTimeout(() => {
+      setIsLoading(false);
+      shopify.close();
+    }, 750);
+  }
+  // [END menu-action-modal.on-submit]
+
+  // [START menu-action-modal.b2b-check]
+  const options = isB2BCustomer ? b2bOptions : dtcOptions;
+  // [END menu-action-modal.b2b-check]
+
+  // [START menu-action-modal.build-ui]
+  return (
+    <s-customer-account-action heading="Report a problem">
+      <s-select
+        label="Select a problem"
+        value={currentProblem}
+        onChange={(e) => setCurrentProblem(e.target.value)}
+      >
+        {options.map((option) => (
+          <s-option key={option.value} value={option.value}>
+            {option.label}
+          </s-option>
+        ))}
+      </s-select>
+
+      <s-button
+        slot="primary-action"
+        loading={isLoading}
+        onClick={() => onSubmit()}
+      >
+        Report
+      </s-button>
+      <s-button slot="secondary-actions" onClick={() => shopify.close()}>
+        Cancel
+      </s-button>
+    </s-customer-account-action>
+  );
+  // [END menu-action-modal.build-ui]
+}

--- a/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/tsconfig.json
+++ b/preact/example-customer-account--order-action-menu--preact/extensions/action-menu-extension-preact/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true
+  }
+}

--- a/preact/example-customer-account--order-action-menu--preact/package.json
+++ b/preact/example-customer-account--order-action-menu--preact/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "customer-account-order-action-menu-app--preact",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "scripts": {
+    "shopify": "shopify",
+    "build": "shopify app build",
+    "dev": "shopify app dev",
+    "info": "shopify app info",
+    "generate": "shopify app generate",
+    "deploy": "shopify app deploy"
+  },
+  "dependencies": {},
+  "trustedDependencies": [
+    "@shopify/plugin-cloudflare"
+  ],
+  "private": true,
+  "workspaces": [
+    "extensions/*"
+  ]
+}

--- a/preact/example-customer-account--order-action-menu--preact/shopify.app.toml
+++ b/preact/example-customer-account--order-action-menu--preact/shopify.app.toml
@@ -1,0 +1,19 @@
+# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+name = "ca-order-action-menu"
+application_url = "https://shopify.dev/apps/default-app-home"
+embedded = true
+
+[build]
+automatically_update_urls_on_dev = true
+include_config_on_deploy = true
+
+[webhooks]
+api_version = "2025-10"
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+scopes = "customer_read_customers,customer_read_orders"
+
+[auth]
+redirect_urls = [ "https://shopify.dev/apps/default-app-home/api/auth" ]

--- a/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/src/MenuActionModalExtension.jsx
+++ b/preact/example-customer-account--pre-auth--preact/extensions/customer-account-pre-auth-note/src/MenuActionModalExtension.jsx
@@ -25,14 +25,12 @@ function MenuActionModalExtension() {
 
   return (
     <s-customer-account-action heading="Add a note to the order">
-      <s-stack direction="block">
-        <s-text-area
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-          rows={3}
-          label="Note for the order"
-        />
-      </s-stack>
+      <s-text-area
+        value={note}
+        onChange={(e) => setNote(e.target.value)}
+        rows={3}
+        label="Note for the order"
+      />
 
       <s-button slot="primary-action" type="submit" onClick={saveNote}>
         Add note


### PR DESCRIPTION
Closes https://github.com/shop/issues-checkout/issues/7753

Migrates the order action example app to Preact. 

The app renders a `Report problem` order action on the details and list pages: 

<img width="1165" height="232" alt="Screenshot 2025-09-12 at 1 32 24 PM" src="https://github.com/user-attachments/assets/a3b1b51c-1c19-4e86-a35a-d62251f81365" />

And a customer account action to select a problem and report: 

<img width="686" height="231" alt="Screenshot 2025-09-12 at 1 32 31 PM" src="https://github.com/user-attachments/assets/58d841a0-658f-489f-9c04-de81e8d49bac" />

If you are testing: 

- Make sure your app has access to customer data and these scopes: `customer_read_customers,customer_read_orders`
- Make sure you are testing an order from the last 60 days
- We can 🍐 tophat to make it easier

I added a task on the issue for this docs migration to make sure we mention these requirements in the prerequisites: https://github.com/shop/issues-checkout/issues/7681#issuecomment-3286290081