### PR TITLE
Migrate metafields extension to Preact with declarative custom data definitions

### DIFF
--- a/preact/example-customer-account--metafields--preact/.gitignore
+++ b/preact/example-customer-account--metafields--preact/.gitignore
@@ -1,0 +1,3 @@
+/node_modules
+/extensions/**/dist
+.DS_Store

--- a/preact/example-customer-account--metafields--preact/.npmrc
+++ b/preact/example-customer-account--metafields--preact/.npmrc
@@ -1,0 +1,4 @@
+engine-strict=true
+auto-install-peers=true
+shamefully-hoist=true
+@shopify:registry=https://registry.npmjs.org

--- a/preact/example-customer-account--metafields--preact/README.md
+++ b/preact/example-customer-account--metafields--preact/README.md
@@ -1,0 +1,78 @@
+# Shopify App Template - Extension only
+
+This is a template for building an [extension-only Shopify app](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app). It contains the basics for building a Shopify app that uses only app extensions.
+
+This template doesn't include a server or the ability to embed a page in the Shopify Admin. If you want either of these capabilities, choose the [Remix app template](https://github.com/Shopify/shopify-app-template-remix) instead.
+
+Whether you choose to use this template or another one, you can use your preferred package manager and the Shopify CLI with [these steps](#installing-the-template).
+
+## Benefits
+
+Shopify apps are built on a variety of Shopify tools to create a great merchant experience. The [create an app](https://shopify.dev/docs/apps/getting-started/create) tutorial in our developer documentation will guide you through creating a Shopify app.
+
+This app template does little more than install the CLI and scaffold a repository.
+
+## Getting started
+
+### Requirements
+
+1. You must [download and install Node.js](https://nodejs.org/en/download/) if you don't already have it.
+1. You must [create a Shopify partner account](https://partners.shopify.com/signup) if you don’t have one.
+1. You must create a store for testing if you don't have one, either a [development store](https://help.shopify.com/en/partners/dashboard/development-stores#create-a-development-store) or a [Shopify Plus sandbox store](https://help.shopify.com/en/partners/dashboard/managing-stores/plus-sandbox-store).
+
+### Installing the template
+
+This template can be installed using your preferred package manager:
+
+Using yarn:
+
+```shell
+yarn create @shopify/app
+```
+
+Using npm:
+
+```shell
+npm init @shopify/app@latest
+```
+
+Using pnpm:
+
+```shell
+pnpm create @shopify/app@latest
+```
+
+This will clone the template and install the required dependencies.
+
+#### Local Development
+
+[The Shopify CLI](https://shopify.dev/docs/apps/tools/cli) connects to an app in your Partners dashboard. It provides environment variables and runs commands in parallel.
+
+You can develop locally using your preferred package manager. Run one of the following commands from the root of your app.
+
+Using yarn:
+
+```shell
+yarn dev
+```
+
+Using npm:
+
+```shell
+npm run dev
+```
+
+Using pnpm:
+
+```shell
+pnpm run dev
+```
+
+Open the URL generated in your console. Once you grant permission to the app, you can start development (such as generating extensions).
+
+## Developer resources
+
+- [Introduction to Shopify apps](https://shopify.dev/docs/apps/getting-started)
+- [App extensions](https://shopify.dev/docs/apps/build/app-extensions)
+- [Extension only apps](https://shopify.dev/docs/apps/build/app-extensions/build-extension-only-app)
+- [Shopify CLI](https://shopify.dev/docs/apps/tools/cli)

--- a/preact/example-customer-account--metafields--preact/extensions/customer-preferences/locales/en.default.json
+++ b/preact/example-customer-account--metafields--preact/extensions/customer-preferences/locales/en.default.json
@@ -1,0 +1,12 @@
+{
+  "preferenceCard": {
+    "heading": "Preferences",
+    "nickName": {
+      "label": "Nickname"
+    },
+    "edit": "Edit",
+    "modalHeading": "Edit preferences",
+    "save": "Save",
+    "cancel": "Cancel"
+  }
+}

--- a/preact/example-customer-account--metafields--preact/extensions/customer-preferences/locales/fr.json
+++ b/preact/example-customer-account--metafields--preact/extensions/customer-preferences/locales/fr.json
@@ -1,0 +1,12 @@
+{
+  "preferenceCard": {
+    "heading": "Préférences",
+    "nickName": {
+      "label": "Surnom"
+    },
+    "edit": "Modifier",
+    "modalHeading": "Modifier les préférences",
+    "save": "Sauvegarder",
+    "cancel": "Annuler"
+  }
+}

--- a/preact/example-customer-account--metafields--preact/extensions/customer-preferences/package.json
+++ b/preact/example-customer-account--metafields--preact/extensions/customer-preferences/package.json
@@ -1,0 +1,11 @@
+{
+  "name": "customer-preferences",
+  "private": true,
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "dependencies": {
+    "preact": "^10.10.x",
+    "@preact/signals": "^2.3.x",
+    "@shopify/ui-extensions": "~2025.10.0-rc"
+  }
+}

--- a/preact/example-customer-account--metafields--preact/extensions/customer-preferences/shopify.d.ts
+++ b/preact/example-customer-account--metafields--preact/extensions/customer-preferences/shopify.d.ts
@@ -1,0 +1,7 @@
+import '@shopify/ui-extensions';
+
+//@ts-ignore
+declare module './src/ProfilePreferenceExtension.jsx' {
+  const shopify: import('@shopify/ui-extensions/customer-account.profile.block.render').Api;
+  const globalThis: { shopify: typeof shopify };
+}

--- a/preact/example-customer-account--metafields--preact/extensions/customer-preferences/shopify.extension.toml
+++ b/preact/example-customer-account--metafields--preact/extensions/customer-preferences/shopify.extension.toml
@@ -1,0 +1,18 @@
+# Learn more about configuring your Customer account UI extension:
+# https://shopify.dev/api/customer-account-ui-extensions/2024-10/configuration
+
+# The version of APIs your extension will receive. Learn more:
+# https://shopify.dev/docs/api/usage/versioning
+api_version = "2025-10"
+
+[[extensions]]
+name = "customer-preferences"
+handle = "customer-preferences"
+uid = "e0260bd4-f328-fedf-994f-bfeb7e42f14a9089f017"
+type = "ui_extension"
+
+# [START setup-targets.config]
+[[extensions.targeting]]
+module = "./src/ProfilePreferenceExtension.jsx"
+target = "customer-account.profile.block.render"
+# [END setup-targets.config]

--- a/preact/example-customer-account--metafields--preact/extensions/customer-preferences/src/ProfilePreferenceExtension.jsx
+++ b/preact/example-customer-account--metafields--preact/extensions/customer-preferences/src/ProfilePreferenceExtension.jsx
@@ -1,0 +1,180 @@
+// @ts-nocheck
+import {render} from 'preact';
+import {useState, useRef} from 'preact/hooks';
+
+// [START setup-targets.extension]
+export default async () => {
+  const {customerId, nickName} = await getCustomerPreferences();
+
+  render(
+    <ProfilePreferenceExtension customerId={customerId} nickName={nickName} />,
+    document.body
+  );
+};
+// [END setup-targets.extension]
+
+function ProfilePreferenceExtension(props) {
+  const {i18n} = shopify;
+  const modalRef = useRef();
+  const [loading, setLoading] = useState(false);
+  const [nickName, setNickName] = useState(props.nickName ?? '');
+  const [newNickName, setNewNickName] = useState(nickName);
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    setLoading(true);
+    const updatedNickname = await setCustomerPreferences(
+      props.customerId,
+      newNickName
+    );
+    setNickName(updatedNickname);
+    setLoading(false);
+    modalRef.current?.hideOverlay();
+  };
+
+  const handleCancel = () => {
+    modalRef.current?.hideOverlay();
+  };
+
+  // [START build-extension.ui]
+  return (
+    <>
+      <s-section>
+        <s-stack direction="block" gap="large-200">
+          <s-heading>
+            <s-stack direction="inline" gap="small-100">
+              <s-text>{i18n.translate('preferenceCard.heading')}</s-text>
+              <s-link
+                aria-label={i18n.translate('preferenceCard.edit')}
+                command="--show"
+                commandFor="profile-preference-modal"
+              >
+                <s-icon type="edit" size="small" />
+              </s-link>
+            </s-stack>
+          </s-heading>
+          <s-stack direction="block" gap="small-500">
+            <s-text color="subdued">
+              {i18n.translate('preferenceCard.nickName.label')}
+            </s-text>
+            <s-text>{nickName}</s-text>
+          </s-stack>
+        </s-stack>
+      </s-section>
+
+      <s-modal
+        id="profile-preference-modal"
+        ref={modalRef}
+        heading={i18n.translate('preferenceCard.modalHeading')}
+      >
+        <s-form onSubmit={handleSubmit}>
+          <s-stack direction="block" gap="large">
+            <s-stack direction="block">
+              <s-text-field
+                label={i18n.translate('preferenceCard.nickName.label')}
+                value={newNickName}
+                onInput={(e) => setNewNickName(e.currentTarget.value)}
+              />
+            </s-stack>
+            <s-stack direction="inline" gap="base" justifyContent="end">
+              <s-button
+                slot="secondary-actions"
+                variant="secondary"
+                disabled={loading}
+                onClick={handleCancel}
+              >
+                {i18n.translate('preferenceCard.cancel')}
+              </s-button>
+              <s-button
+                slot="primary-action"
+                type="submit"
+                variant="primary"
+                loading={loading}
+              >
+                {i18n.translate('preferenceCard.save')}
+              </s-button>
+            </s-stack>
+          </s-stack>
+        </s-form>
+      </s-modal>
+    </>
+  );
+  // [END build-extension.ui]
+}
+
+// [START build-extension.get-value]
+async function getCustomerPreferences() {
+  const response = await fetch(
+    'shopify:customer-account/api/2025-10/graphql.json',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: `query preferences($key: String!, $namespace: String!) {
+          customer {
+          id
+            metafield(namespace: $namespace, key: $key) {
+              value
+            }
+          }
+        }`,
+        variables: {
+          key: 'nickname',
+          namespace: '$app',
+        },
+      }),
+    }
+  );
+
+  const {data} = await response.json();
+
+  return {
+    customerId: data.customer.id,
+    nickName: data.customer.metafield?.value,
+  };
+}
+// [END build-extension.get-value]
+
+// [START write-metafield.mutation]
+async function setCustomerPreferences(customerId, nickName) {
+  const response = await fetch(
+    'shopify:customer-account/api/2025-10/graphql.json',
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        query: `mutation setPreferences($metafields: [MetafieldsSetInput!]!) {
+          metafieldsSet(metafields: $metafields) {
+            metafields {
+              value
+            }
+            userErrors {
+              field
+              message
+            }
+          }
+        }`,
+        variables: {
+          metafields: [
+            {
+              key: 'nickname',
+              namespace: '$app',
+              type: 'single_line_text_field',
+              ownerId: customerId,
+              value: nickName ?? '',
+            },
+          ],
+        },
+      }),
+    }
+  );
+
+  const {data} = await response.json();
+
+  return data.metafieldsSet.metafields[0].value;
+}
+// [END write-metafield.mutation]

--- a/preact/example-customer-account--metafields--preact/extensions/customer-preferences/tsconfig.json
+++ b/preact/example-customer-account--metafields--preact/extensions/customer-preferences/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "jsx": "react-jsx",
+    "jsxImportSource": "preact",
+    "target": "ES2020",
+    "checkJs": true,
+    "allowJs": true,
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "noEmit": true
+  }
+}

--- a/preact/example-customer-account--metafields--preact/package.json
+++ b/preact/example-customer-account--metafields--preact/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "customer-account-metafields-app--preact",
+  "version": "1.0.0",
+  "license": "UNLICENSED",
+  "scripts": {
+    "shopify": "shopify",
+    "build": "shopify app build",
+    "dev": "shopify app dev",
+    "info": "shopify app info",
+    "generate": "shopify app generate",
+    "deploy": "shopify app deploy"
+  },
+  "dependencies": {},
+  "trustedDependencies": [
+    "@shopify/plugin-cloudflare"
+  ],
+  "private": true,
+  "workspaces": [
+    "extensions/*"
+  ]
+}

--- a/preact/example-customer-account--metafields--preact/shopify.app.toml
+++ b/preact/example-customer-account--metafields--preact/shopify.app.toml
@@ -1,0 +1,26 @@
+# Learn more about configuring your app at https://shopify.dev/docs/apps/tools/cli/configuration
+
+name = "ca-metafields"
+application_url = "https://shopify.dev/apps/default-app-home"
+embedded = true
+
+[build]
+automatically_update_urls_on_dev = true
+include_config_on_deploy = true
+
+[webhooks]
+api_version = "2025-10"
+
+[access_scopes]
+# Learn more at https://shopify.dev/docs/apps/tools/cli/configuration#access_scopes
+scopes = "write_customers, customer_write_customers"
+
+[auth]
+redirect_urls = [ "https://shopify.dev/apps/default-app-home/api/auth" ]
+
+[customer.metafields.app.nickname]
+type = "single_line_text_field"
+name = "The customer's preferred name"
+description = "The customer's preferred nickname for personalization"
+access.customer_account = "read_write"
+access.admin = "merchant_read"


### PR DESCRIPTION
Closes https://github.com/shop/issues-checkout/issues/7752

- Migrates the metafields example app to Preact
- Takes advantage of [declarative custom data definitions](https://shopify.dev/docs/beta/next-gen-dev-platform/declarative-custom-data-definitions), no more need for a server in the example app.

The extension has a profile block extension to show the customer's nickname which is stored in a customer metafield: 

<img width="1152" height="159" alt="Screenshot 2025-09-13 at 11 15 52 AM" src="https://github.com/user-attachments/assets/fbb57335-2c50-465c-9468-6b2356c2978b" />

The extension allows the customer to edit their nickname in a modal:

<img width="569" height="239" alt="Screenshot 2025-09-13 at 11 15 58 AM" src="https://github.com/user-attachments/assets/57800f53-5880-4dcb-a0e8-8a40abc1556c" />

For testing: 

- Make sure you have requested [customer data access](https://shopify.dev/docs/apps/launch/protected-customer-data) for your app
- Make sure your app has these scopes: `write_customers, customer_write_customers`
- We can also 🍐 to test 