### PR TITLE
Update fulfillment extension to use Button instead of Link

### DIFF
--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/src/FulfillmentDelivery.jsx
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-fulfillment/src/FulfillmentDelivery.jsx
@@ -12,7 +12,7 @@ function CustomerFulfillmentDetailsDelivery() {
       <s-divider />
       <s-text>Tell us how we did for a chance to win 1000 points</s-text>
       <s-stack direction="block" max-inline-size="150">
-        <s-link>Write a review</s-link>
+        <s-button>Write a review</s-button>
       </s-stack>
     </s-stack>
   );


### PR DESCRIPTION
Changing this to better match the existing screenshot from our tutorial docs: 

Docs: 

<img width="699" height="271" alt="Screenshot 2025-09-18 at 10 33 32 AM" src="https://github.com/user-attachments/assets/65843ff1-1476-41b8-be10-129555ae148a" />

Extension: 

<img width="692" height="424" alt="Screenshot 2025-09-18 at 10 33 53 AM" src="https://github.com/user-attachments/assets/1c1d0f1b-5b59-4c47-b592-c025d288b594" />

