### PR TITLE
Update tutorials to match images in docs

### DIFF
--- a/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-block/src/PointsBlockExtension.jsx
+++ b/preact/example-customer-account--loyalty-app--preact/extensions/ca-loyalty-order-status-block/src/PointsBlockExtension.jsx
@@ -8,7 +8,7 @@ export default async () => {
 // [START order-status-block.build-ui]
 function PromotionBanner() {
   return (
-    <s-banner>
+    <s-banner tone="success">
       <s-stack direction="block" inline-alignment="center">
         <s-text>
           🎉 You've earned 1,000 points from this order. You've been upgraded to

--- a/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/src/ProfileBlockExtension.jsx
+++ b/preact/example-customer-account--wishlist--preact/extensions/wishlist-profile-block/src/ProfileBlockExtension.jsx
@@ -1,19 +1,28 @@
 import '@shopify/ui-extensions/preact';
 import {render} from 'preact';
 
-// [START block.build-ui]
 export default async () => {
   render(<BlockExtension />, document.body);
 };
 
+// [START block.build-ui]
 function BlockExtension() {
   return (
     <s-section>
-      <s-stack direction="inline" inline-alignment="center" gap="small-400">
-        <s-text>Grow your garden with more plants from your wishlist.</s-text>
-        <s-link href="extension:wishlist-extension-preact/">
+      <s-stack
+        direction="inline"
+        justifyContent="space-between"
+        alignItems="center"
+      >
+        <s-stack direction="block" gap="small-400">
+          <s-heading>My Wishlist</s-heading>
+          <s-text>
+            View your favorites and save new looks in your wishlist collections.
+          </s-text>
+        </s-stack>
+        <s-button variant="primary" href="extension:wishlist-extension-preact/">
           View wishlist
-        </s-link>
+        </s-button>
       </s-stack>
     </s-section>
   );


### PR DESCRIPTION
Update two tutorials to match the new images in the the dev docs.

Order status block with success tone: 

<img width="1165" height="573" alt="Screenshot 2025-10-06 at 4 37 38 PM" src="https://github.com/user-attachments/assets/a04f3c3c-fcaf-4a40-bd9d-5af629b03521" />

Profile block  with new layout and code block tag moved, I also updated the text after the screenshot: 

<img width="1164" height="278" alt="Screenshot 2025-10-06 at 4 46 28 PM" src="https://github.com/user-attachments/assets/58bba83a-c580-4388-972d-efe974f54979" />
